### PR TITLE
Fix token expiry getter

### DIFF
--- a/authorization/authorization_code_pkce/public/app.js
+++ b/authorization/authorization_code_pkce/public/app.js
@@ -18,7 +18,7 @@ const scope = 'user-read-private user-read-email';
 const currentToken = {
   get access_token() { return localStorage.getItem('access_token') || null; },
   get refresh_token() { return localStorage.getItem('refresh_token') || null; },
-  get expires_in() { return localStorage.getItem('refresh_in') || null },
+  get expires_in() { return localStorage.getItem('expires_in') || null },
   get expires() { return localStorage.getItem('expires') || null },
 
   save: function (response) {
@@ -33,33 +33,43 @@ const currentToken = {
   }
 };
 
-// On page load, try to fetch auth code from current browser search URL
-const args = new URLSearchParams(window.location.search);
-const code = args.get('code');
+async function main() {
+  // On page load, try to fetch auth code from current browser search URL
+  const args = new URLSearchParams(window.location.search);
+  const code = args.get('code');
 
-// If we find a code, we're in a callback, do a token exchange
-if (code) {
-  const token = await getToken(code);
-  currentToken.save(token);
+  // If we find a code, we're in a callback, do a token exchange
+  if (code) {
+    const token = await getToken(code);
+    currentToken.save(token);
 
-  // Remove code from URL so we can refresh correctly.
-  const url = new URL(window.location.href);
-  url.searchParams.delete("code");
+    // Remove code from URL so we can refresh correctly.
+    const url = new URL(window.location.href);
+    url.searchParams.delete("code");
 
-  const updatedUrl = url.search ? url.href : url.href.replace('?', '');
-  window.history.replaceState({}, document.title, updatedUrl);
+    const updatedUrl = url.search ? url.href : url.href.replace('?', '');
+    window.history.replaceState({}, document.title, updatedUrl);
+  }
+
+  // If we have a token, we're logged in, so fetch user data and render logged in template
+  if (currentToken.access_token) {
+    const userData = await getUserData();
+    renderTemplate("main", "logged-in-template", userData);
+    renderTemplate("oauth", "oauth-template", currentToken);
+  }
+
+  // Otherwise we're not logged in, so render the login template
+  if (!currentToken.access_token) {
+    renderTemplate("main", "login");
+  }
 }
 
-// If we have a token, we're logged in, so fetch user data and render logged in template
-if (currentToken.access_token) {
-  const userData = await getUserData();
-  renderTemplate("main", "logged-in-template", userData);
-  renderTemplate("oauth", "oauth-template", currentToken);
+if (typeof window !== 'undefined') {
+  main();
 }
 
-// Otherwise we're not logged in, so render the login template
-if (!currentToken.access_token) {
-  renderTemplate("main", "login");
+if (typeof module !== 'undefined') {
+  module.exports = { currentToken };
 }
 
 async function redirectToSpotifyAuthorize() {

--- a/authorization/authorization_code_pkce/public/app.test.js
+++ b/authorization/authorization_code_pkce/public/app.test.js
@@ -1,0 +1,30 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+class LocalStorageMock {
+  constructor() {
+    this.store = {};
+  }
+  clear() {
+    this.store = {};
+  }
+  getItem(key) {
+    return Object.prototype.hasOwnProperty.call(this.store, key)
+      ? this.store[key]
+      : null;
+  }
+  setItem(key, value) {
+    this.store[key] = String(value);
+  }
+}
+
+global.localStorage = new LocalStorageMock();
+
+const { currentToken } = require('./app.js');
+
+test('currentToken saves and retrieves expires_in from localStorage', () => {
+  const token = { access_token: 'abc', refresh_token: 'def', expires_in: 3600 };
+  currentToken.save(token);
+  assert.strictEqual(currentToken.expires_in, String(token.expires_in));
+  assert.strictEqual(localStorage.getItem('expires_in'), String(token.expires_in));
+});


### PR DESCRIPTION
## Summary
- make app.js runnable in non-browser environments and export token helper
- add unit test ensuring token expiration is saved and read from localStorage

## Testing
- `node --test authorization/authorization_code_pkce/public/app.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68921675f0d08332b049572f3d191025