### PR TITLE
Remove deprecated Buffer usage in auth code example

### DIFF
--- a/authorization/authorization_code/app.js
+++ b/authorization/authorization_code/app.js
@@ -76,7 +76,7 @@ app.get('/callback', function(req, res) {
       },
       headers: {
         'content-type': 'application/x-www-form-urlencoded',
-        Authorization: 'Basic ' + (new Buffer.from(client_id + ':' + client_secret).toString('base64'))
+        Authorization: 'Basic ' + Buffer.from(client_id + ':' + client_secret).toString('base64')
       },
       json: true
     };
@@ -121,7 +121,7 @@ app.get('/refresh_token', function(req, res) {
     url: 'https://accounts.spotify.com/api/token',
     headers: { 
       'content-type': 'application/x-www-form-urlencoded',
-      'Authorization': 'Basic ' + (new Buffer.from(client_id + ':' + client_secret).toString('base64')) 
+      'Authorization': 'Basic ' + Buffer.from(client_id + ':' + client_secret).toString('base64')
     },
     form: {
       grant_type: 'refresh_token',


### PR DESCRIPTION
## Summary
- replace `new Buffer.from` with `Buffer.from` in authorization headers

## Testing
- `npm test` (fails: Missing script)
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_68921676cdf0833287710087ea1731fe