### PR TITLE
Fix typo in Spotify API comment

### DIFF
--- a/authorization/authorization_code_pkce/public/app.js
+++ b/authorization/authorization_code_pkce/public/app.js
@@ -92,7 +92,7 @@ async function redirectToSpotifyAuthorize() {
   window.location.href = authUrl.toString(); // Redirect the user to the authorization server for login
 }
 
-// Soptify API Calls
+// Spotify API Calls
 async function getToken(code) {
   const code_verifier = localStorage.getItem('code_verifier');
 


### PR DESCRIPTION
## Summary
- correct misspelled 'Soptify API Calls' comment to 'Spotify API Calls' in the authorization code PKCE sample

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68921677da4c83329ab8281e6d277f41