### PR TITLE
feat: add infinite scroll for playlists and tracks

### DIFF
--- a/get_user_profile/components/playlistDetail.tsx
+++ b/get_user_profile/components/playlistDetail.tsx
@@ -1,27 +1,24 @@
-import React, { useEffect, useRef, useState } from "react";
-import { fetchPlaylistItems } from "../pages/api/playlist";
+import React, { useEffect, useRef } from "react";
+
 interface PlaylistDetailProps {
   playlistDetail: SpotifyPlaylistResponse;
-  additionalPlaylistItems: SpotifyPlaylistTracksResponse | null;
   trackFeatures: { [key: string]: SpotifyAudioFeaturesResponse };
-  handlePrevious?: () => void;
   handleNext?: () => void;
 }
 
 export const PlaylistDetail: React.FC<PlaylistDetailProps> = ({
   playlistDetail,
-  additionalPlaylistItems,
   trackFeatures,
   handleNext,
 }) => {
-  const [items, setItems] = useState(playlistDetail.tracks.items);
-  const loaderRef = useRef(null);
+  const loaderRef = useRef<HTMLDivElement | null>(null);
 
   function displayArtistNames(artists: SpotifyArtistObject[]): string {
     return artists.map((artist) => artist.name).join(", ");
   }
 
   useEffect(() => {
+    if (!handleNext) return;
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries[0].isIntersecting && playlistDetail.tracks.next) {
@@ -38,20 +35,7 @@ export const PlaylistDetail: React.FC<PlaylistDetailProps> = ({
     return () => {
       observer.disconnect();
     };
-  }, [playlistDetail.tracks.next]);
-
-  //   const fetchMoreItems = async () => {
-
-  //     const moreItems = await fetchPlaylistItems(,playlistDetail.tracks.next);
-  //     setItems([...items, ...moreItems]);
-  //   };
-
-  useEffect(() => {
-    // Assuming handleNext updates the items and playlistDetail.tracks.next
-    if (additionalPlaylistItems) {
-      setItems([...items, ...additionalPlaylistItems.items]);
-    }
-  }, [additionalPlaylistItems]);
+  }, [handleNext, playlistDetail.tracks.next]);
 
   return (
     <>
@@ -63,7 +47,7 @@ export const PlaylistDetail: React.FC<PlaylistDetailProps> = ({
           Playlist: {playlistDetail.name}
         </h2>
         <div className="space-y-4">
-          {items.map((item, index) => {
+          {playlistDetail.tracks.items.map((item, index) => {
             const features = trackFeatures[item.track.id];
             return (
               <div key={index} className="bg-gray-700 p-4 rounded-lg shadow">
@@ -108,79 +92,3 @@ export const PlaylistDetail: React.FC<PlaylistDetailProps> = ({
   );
 };
 
-// import React from "react";
-
-// interface PlaylistDetailProps {
-//   playlistDetail: SpotifyPlaylistResponse;
-//   additionalPlaylistItems: SpotifyPlaylistTracksResponse | null;
-//   handlePrevious?: () => void;
-//   handleNext?: () => void;
-// }
-// export const PlaylistDetail: React.FC<PlaylistDetailProps> = ({
-//   playlistDetail,
-//   additionalPlaylistItems,
-//   handlePrevious,
-//   handleNext,
-// }) => {
-//   function displayArtistNames(artists: SpotifyArtistObject[]): string {
-//     return artists.map((artist) => artist.name).join(", ");
-//   }
-//   console.log(additionalPlaylistItems);
-//   return (
-//     <>
-//       <section
-//         id="playlist-detail"
-//         className="bg-gray-800 text-white p-5 rounded-lg shadow-lg"
-//       >
-//         <h2 className="text-2xl font-bold mb-4">
-//           Playlist: {playlistDetail.name}
-//         </h2>
-//         <div className="space-y-4">
-//           {playlistDetail.tracks.items.length > 0 &&
-//             playlistDetail.tracks.items.map((item, index) => (
-//               <div key={index} className="bg-gray-700 p-4 rounded-lg shadow">
-//                 <h3 className="text-xl font-semibold">{item.track.name}</h3>
-//                 <p className="text-gray-400">
-//                   {displayArtistNames(item.track.artists)}
-//                 </p>
-//                 <div className="mt-2">
-//                   <a
-//                     href={item.track.external_urls.spotify}
-//                     target="_blank"
-//                     rel="noopener noreferrer"
-//                     className="text-blue-400 hover:text-blue-300 transition duration-300 ease-in-out"
-//                   >
-//                     Listen on Spotify
-//                   </a>
-//                 </div>
-//               </div>
-//             ))}
-//         </div>
-//         <div className="flex flex-row gap-4 pb-4 justify-center mt-6">
-//           {playlistDetail.tracks.previous && (
-//             <button
-//               onClick={handlePrevious}
-//               className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
-//             >
-//               前へ
-//             </button>
-//           )}
-//           {playlistDetail.tracks.next && (
-//             <button
-//               onClick={handleNext}
-//               className="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded"
-//             >
-//               次へ
-//             </button>
-//           )}
-//         </div>
-//         <a
-//           href="/playlists"
-//           className="text-blue-500 hover:text-blue-700 transition duration-300 ease-in-out"
-//         >
-//           戻る
-//         </a>
-//       </section>
-//     </>
-//   );
-// };

--- a/get_user_profile/pages/playlists/[id].tsx
+++ b/get_user_profile/pages/playlists/[id].tsx
@@ -73,6 +73,14 @@ const PlaylistDetailPage = () => {
           playlistDetail.tracks.next
         );
 
+        // Deduplicate tracks by ID before updating state
+        const uniqueItems = tracks.items.filter(
+          (item) =>
+            !playlistDetail.tracks.items.some(
+              (existing) => existing.track.id === item.track.id
+            )
+        );
+
         // プレイリスト情報を更新（トラックを追加し next を更新）
         setPlaylistDetail((prev) =>
           prev
@@ -80,7 +88,7 @@ const PlaylistDetailPage = () => {
                 ...prev,
                 tracks: {
                   ...prev.tracks,
-                  items: [...prev.tracks.items, ...tracks.items],
+                  items: [...prev.tracks.items, ...uniqueItems],
                   next: tracks.next,
                   previous: tracks.previous,
                 },
@@ -89,7 +97,7 @@ const PlaylistDetailPage = () => {
         );
 
         // 新しく取得したトラックの音響特徴量を取得
-        const featuresPromises = tracks.items.map((item) =>
+        const featuresPromises = uniqueItems.map((item) =>
           fetchAudioFeatures(storedAccessToken, item.track.id)
         );
         const features = await Promise.all(featuresPromises);

--- a/get_user_profile/pages/playlists/[id].tsx
+++ b/get_user_profile/pages/playlists/[id].tsx
@@ -4,18 +4,21 @@ import { fetchPlaylist, fetchPlaylistItems } from "../api/playlist";
 import { fetchAudioFeatures } from "../api/track";
 import { PlaylistDetail } from "../../components/playlistDetail";
 import { redirectToAuthCodeFlow } from "../../../get_user_profile/src/authCodeWithPkce";
+
 const clientId = process.env.NEXT_PUBLIC_SPOTIFY_CLIENT_ID;
+
 const PlaylistDetailPage = () => {
   const [playlistDetail, setPlaylistDetail] =
     useState<SpotifyPlaylistResponse | null>(null);
-  const [additionalPlaylistItems, setAdditionalPlaylistItems] =
-    useState<SpotifyPlaylistTracksResponse | null>(null);
   const [trackFeatures, setTrackFeatures] = useState<{
     [key: string]: SpotifyAudioFeaturesResponse;
   }>({});
+  const [loading, setLoading] = useState(false);
   const router = useRouter();
   const { id } = router.query;
   const playlistId = typeof id === "string" ? id : undefined;
+
+  // 初回のプレイリスト情報とトラック情報を取得
   useEffect(() => {
     const fetchData = async () => {
       const accessToken = localStorage.getItem("access_token");
@@ -32,6 +35,8 @@ const PlaylistDetailPage = () => {
             0
           );
           setPlaylistDetail(playlistData);
+
+          // トラックの音響特徴量を取得
           const featuresPromises = playlistData.tracks.items.map((track) =>
             fetchAudioFeatures(accessToken, track.track.id)
           );
@@ -39,7 +44,7 @@ const PlaylistDetailPage = () => {
           const featuresMap = features.reduce((acc, feature) => {
             acc[feature.id] = feature;
             return acc;
-          }, {});
+          }, {} as { [key: string]: SpotifyAudioFeaturesResponse });
           setTrackFeatures(featuresMap);
         }
       } catch (error) {
@@ -51,38 +56,65 @@ const PlaylistDetailPage = () => {
       fetchData();
     }
   }, [playlistId, clientId]);
-  useEffect(() => {
-    console.log(trackFeatures);
-  }, [trackFeatures]);
 
-  if (!playlistDetail) {
-    return <div>Loading...</div>;
-  }
+  // 追加読み込み処理
   const handleNext = async () => {
-    if (!clientId) return;
+    if (!clientId || !playlistDetail || !playlistDetail.tracks.next || loading)
+      return;
     try {
+      setLoading(true);
       const storedAccessToken = localStorage.getItem("access_token");
       if (!storedAccessToken) {
         router.push("/");
         redirectToAuthCodeFlow(clientId);
       } else {
-        if (playlistDetail && playlistDetail.tracks.next) {
-          const tracks = await fetchPlaylistItems(
-            storedAccessToken,
-            playlistDetail.tracks.next
-          );
-          setAdditionalPlaylistItems(tracks);
-        }
+        const tracks = await fetchPlaylistItems(
+          storedAccessToken,
+          playlistDetail.tracks.next
+        );
+
+        // プレイリスト情報を更新（トラックを追加し next を更新）
+        setPlaylistDetail((prev) =>
+          prev
+            ? {
+                ...prev,
+                tracks: {
+                  ...prev.tracks,
+                  items: [...prev.tracks.items, ...tracks.items],
+                  next: tracks.next,
+                  previous: tracks.previous,
+                },
+              }
+            : prev
+        );
+
+        // 新しく取得したトラックの音響特徴量を取得
+        const featuresPromises = tracks.items.map((item) =>
+          fetchAudioFeatures(storedAccessToken, item.track.id)
+        );
+        const features = await Promise.all(featuresPromises);
+        const featuresMap = features.reduce((acc, feature) => {
+          acc[feature.id] = feature;
+          return acc;
+        }, {} as { [key: string]: SpotifyAudioFeaturesResponse });
+
+        setTrackFeatures((prev) => ({ ...prev, ...featuresMap }));
       }
     } catch (error) {
       console.error("Failed to fetch playlist items:", error);
+    } finally {
+      setLoading(false);
     }
   };
+
+  if (!playlistDetail) {
+    return <div>Loading...</div>;
+  }
+
   return (
     <div>
       <PlaylistDetail
         playlistDetail={playlistDetail}
-        additionalPlaylistItems={additionalPlaylistItems}
         trackFeatures={trackFeatures}
         handleNext={handleNext}
       />
@@ -91,104 +123,3 @@ const PlaylistDetailPage = () => {
 };
 
 export default PlaylistDetailPage;
-
-// import React, { useEffect, useState } from "react";
-// import { Playlists } from "../../components/playlists";
-// import { fetchPlaylist, fetchPlaylistItems } from "../../pages/api/playlist";
-// import {
-//   redirectToAuthCodeFlow,
-//   getAccessToken,
-// } from "../../../get_user_profile/src/authCodeWithPkce";
-// import { useRouter } from "next/router";
-// import { PlaylistDetail } from "../../components/playlistDetail";
-
-// const clientId = process.env.NEXT_PUBLIC_SPOTIFY_CLIENT_ID;
-// export default function PlaylistDetailPage() {
-//   const [playlistDetail, setPlaylistDetail] =
-//     useState<SpotifyPlaylistResponse | null>(null);
-//   const [additionalPlaylistItems, setAdditionalPlaylistItems] =
-//     useState<SpotifyPlaylistTracksResponse | null>(null);
-//   const router = useRouter();
-//   const { id } = router.query;
-//   const playlistId = typeof id === "string" ? id : undefined;
-//   useEffect(() => {
-//     const fetchData = async () => {
-//       if (!clientId) return;
-
-//       try {
-//         const storedAccessToken = localStorage.getItem("access_token");
-//         if (!storedAccessToken) {
-//           router.push("/");
-//           redirectToAuthCodeFlow(clientId);
-//         } else {
-//           if (playlistId) {
-//             const playlistData = await fetchPlaylist(
-//               storedAccessToken,
-//               playlistId,
-//               20,
-//               0
-//             );
-//             setPlaylistDetail(playlistData);
-//           }
-//         }
-//       } catch (error) {
-//         console.error("Failed to fetch playlists:", error);
-//       }
-//     };
-
-//     fetchData();
-//   }, [playlistId, clientId, router]);
-//   const handlePrevious = async () => {
-//     if (!clientId) return;
-//     try {
-//       const storedAccessToken = localStorage.getItem("access_token");
-//       if (!storedAccessToken) {
-//         router.push("/");
-//         redirectToAuthCodeFlow(clientId);
-//       } else {
-//         if (playlistDetail && playlistDetail.tracks.previous) {
-//           const tracks = await fetchPlaylistItems(
-//             storedAccessToken,
-//             playlistDetail.tracks.previous
-//           );
-//           setAdditionalPlaylistItems(tracks);
-//         }
-//       }
-//     } catch (error) {
-//       console.error("Failed to fetch playlist items:", error);
-//     }
-//   };
-//   const handleNext = async () => {
-//     if (!clientId) return;
-//     try {
-//       const storedAccessToken = localStorage.getItem("access_token");
-//       if (!storedAccessToken) {
-//         router.push("/");
-//         redirectToAuthCodeFlow(clientId);
-//       } else {
-//         if (playlistDetail && playlistDetail.tracks.next) {
-//           const tracks = await fetchPlaylistItems(
-//             storedAccessToken,
-//             playlistDetail.tracks.next
-//           );
-//           setAdditionalPlaylistItems(tracks);
-//         }
-//       }
-//     } catch (error) {
-//       console.error("Failed to fetch playlist items:", error);
-//     }
-//   };
-//   if (!playlistDetail) {
-//     return <div>Loading...</div>;
-//   }
-//   return (
-//     <div>
-//       <PlaylistDetail
-//         playlistDetail={playlistDetail}
-//         additionalPlaylistItems={additionalPlaylistItems}
-//         handlePrevious={handlePrevious}
-//         handleNext={handleNext}
-//       />
-//     </div>
-//   );
-// }

--- a/get_user_profile/pages/playlists/index.tsx
+++ b/get_user_profile/pages/playlists/index.tsx
@@ -1,10 +1,7 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Playlists } from "../../components/playlists";
 import { fetchPlaylists } from "../../pages/api/playlist";
-import {
-  redirectToAuthCodeFlow,
-  getAccessToken,
-} from "../../../get_user_profile/src/authCodeWithPkce";
+import { redirectToAuthCodeFlow } from "../../../get_user_profile/src/authCodeWithPkce";
 import { useRouter } from "next/router";
 
 const clientId = process.env.NEXT_PUBLIC_SPOTIFY_CLIENT_ID;
@@ -16,6 +13,7 @@ export default function PlaylistsPage() {
   const [loading, setLoading] = useState(false);
   const [offset, setOffset] = useState(0);
   const [hasMore, setHasMore] = useState(true);
+  const loaderRef = useRef<HTMLDivElement | null>(null);
   const fetchData = async () => {
     if (!clientId || !hasMore || loading) return;
     setLoading(true);
@@ -25,7 +23,6 @@ export default function PlaylistsPage() {
         router.push("/");
         redirectToAuthCodeFlow(clientId);
       } else {
-        console.log(offset);
         const playlistsData = await fetchPlaylists(
           storedAccessToken,
           50,
@@ -50,9 +47,6 @@ export default function PlaylistsPage() {
   useEffect(() => {
     const observer = new IntersectionObserver(
       (entries) => {
-        console.log(entries);
-        console.log(hasMore);
-        console.log(loading);
         if (entries[0].isIntersecting && hasMore && !loading) {
           fetchData();
         }
@@ -60,10 +54,8 @@ export default function PlaylistsPage() {
       { threshold: 0.1 }
     );
 
-    // Assume there is a footer element to observe
-    const footer = document.getElementById("footer");
-    if (footer) {
-      observer.observe(footer);
+    if (loaderRef.current) {
+      observer.observe(loaderRef.current);
     }
 
     return () => {
@@ -77,7 +69,7 @@ export default function PlaylistsPage() {
   return (
     <div>
       <Playlists playlists={playlists} />
-      <div id="footer" style={{ height: "20px" }}></div>
+      <div ref={loaderRef} style={{ height: "20px" }}></div>
     </div>
   );
 }

--- a/get_user_profile/pages/playlists/index.tsx
+++ b/get_user_profile/pages/playlists/index.tsx
@@ -28,11 +28,17 @@ export default function PlaylistsPage() {
           50,
           offset
         );
-        //   setPlaylists(playlistsData);
-        setPlaylists((prev) => ({
-          ...playlistsData,
-          items: [...(prev?.items || []), ...playlistsData.items],
-        }));
+        // Deduplicate playlists by ID before updating state
+        setPlaylists((prev) => {
+          const existingItems = prev?.items || [];
+          const newItems = playlistsData.items.filter(
+            (item) => !existingItems.some((p) => p.id === item.id)
+          );
+          return {
+            ...playlistsData,
+            items: [...existingItems, ...newItems],
+          };
+        });
         setOffset((prevOffset) => prevOffset + playlistsData.items.length);
         setHasMore(playlistsData.items.length > 0);
       }


### PR DESCRIPTION
## Summary
- support intersection observer-based infinite scrolling on playlist list
- enable lazy loading of tracks within playlist view with audio features

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68922548143483329b1fe84539ee77f2