### PR TITLE
Handle missing Spotify client ID

### DIFF
--- a/get_user_profile/README.md
+++ b/get_user_profile/README.md
@@ -12,13 +12,17 @@ To run this demo you will need:
 
 ## Usage
 
-Create an app in your [Spotify Developer Dashboard](https://developer.spotify.com/dashboard/), set the redirect URI to ` http://localhost:5173/callback` and `http://localhost:5173/callback/` and copy your Client ID. 
+Create an app in your [Spotify Developer Dashboard](https://developer.spotify.com/dashboard/), set the redirect URI to `http://localhost:3000/callback` and copy your Client ID.
 
-Clone the repository, ensure that you are in the `get_user_profile` directory and run:
+In this directory, create a `.env.local` file and add your Spotify Client ID:
+
+```env
+NEXT_PUBLIC_SPOTIFY_CLIENT_ID=your_client_id_here
+```
+
+Install dependencies and start the development server:
 
 ```bash
 npm install
 npm run dev
 ```
-
-Replace the value for clientId in `/src/script.ts` with your own Client ID.

--- a/get_user_profile/pages/index.tsx
+++ b/get_user_profile/pages/index.tsx
@@ -10,14 +10,23 @@ import { useAuth } from "../src/AuthContext";
 const clientId = process.env.NEXT_PUBLIC_SPOTIFY_CLIENT_ID;
 export default function Home() {
   const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [error, setError] = useState<string | null>(null);
   const { token, setToken } = useAuth();
 
   useEffect(() => {
     const fetchData = async () => {
-      if (!clientId) return;
+      if (!clientId) {
+        setError("Missing Spotify Client ID");
+        return;
+      }
       if (token) {
-        const profileData = await fetchProfile(token);
-        setProfile(profileData);
+        try {
+          const profileData = await fetchProfile(token);
+          setProfile(profileData);
+        } catch (err) {
+          console.error("Failed to fetch profile:", err);
+          setError("Failed to load profile");
+        }
         return;
       }
       const params = new URLSearchParams(window.location.search);
@@ -33,14 +42,18 @@ export default function Home() {
           return;
         }
         setToken(accessToken);
-      } catch (error) {
-        console.error("Failed to fetch profile:", error);
+      } catch (err) {
+        console.error("Failed to fetch profile:", err);
+        setError("Failed to load profile");
       }
     };
 
     fetchData();
   }, [token]);
 
+  if (error) {
+    return <div>{error}</div>;
+  }
   if (!profile) {
     return <div>Loading...</div>;
   }


### PR DESCRIPTION
## Summary
- show clear message when Spotify client ID is missing or profile fetch fails
- document required `NEXT_PUBLIC_SPOTIFY_CLIENT_ID` env var

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892a1311cfc8332b13bd508637e2122