### PR TITLE
Handle localStorage errors to show login screen

### DIFF
--- a/get_user_profile/src/AuthContext.tsx
+++ b/get_user_profile/src/AuthContext.tsx
@@ -15,18 +15,26 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   // Load token from localStorage on initial mount
   useEffect(() => {
     if (typeof window === "undefined") return;
-    const stored = window.localStorage.getItem("access_token");
-    if (stored) {
-      setTokenState(stored);
+    try {
+      const stored = window.localStorage.getItem("access_token");
+      if (stored) {
+        setTokenState(stored);
+      }
+    } catch (e) {
+      console.warn("Failed to read access token from localStorage", e);
     }
   }, []);
 
   const setToken = (newToken: string | null) => {
     if (typeof window !== "undefined") {
-      if (newToken) {
-        window.localStorage.setItem("access_token", newToken);
-      } else {
-        window.localStorage.removeItem("access_token");
+      try {
+        if (newToken) {
+          window.localStorage.setItem("access_token", newToken);
+        } else {
+          window.localStorage.removeItem("access_token");
+        }
+      } catch (e) {
+        console.warn("Failed to write access token to localStorage", e);
       }
     }
     setTokenState(newToken);

--- a/get_user_profile/src/__tests__/AuthContext.test.tsx
+++ b/get_user_profile/src/__tests__/AuthContext.test.tsx
@@ -61,6 +61,25 @@ describe("AuthProvider", () => {
     expect(context.token).toBeNull();
   });
 
+  it("handles localStorage access errors gracefully", async () => {
+    const spy = jest
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation(() => {
+        throw new Error("quota exceeded");
+      });
+
+    await act(async () => {
+      root.render(
+        <AuthProvider>
+          <TestComponent />
+        </AuthProvider>
+      );
+    });
+
+    expect(context.token).toBeNull();
+    spy.mockRestore();
+  });
+
   it("setToken updates token and localStorage", async () => {
     await act(async () => {
       root.render(


### PR DESCRIPTION
## Summary
- gracefully handle localStorage failures in AuthContext
- avoid crashing when persisting verifier or token during auth
- add regression test for localStorage quota errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892adbc51bc8332b9709ce45dfc0d42