### PR TITLE
Persist Spotify auth token and redirect to previous page

### DIFF
--- a/get_user_profile/pages/index.tsx
+++ b/get_user_profile/pages/index.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { useRouter } from "next/router";
 import { Profile } from "../components/profile";
 import { fetchProfile } from "../pages/api/profile";
 import {
@@ -11,6 +12,7 @@ const clientId = process.env.NEXT_PUBLIC_SPOTIFY_CLIENT_ID;
 export default function Home() {
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
   const { token, setToken } = useAuth();
 
   useEffect(() => {
@@ -42,6 +44,12 @@ export default function Home() {
           return;
         }
         setToken(accessToken);
+        const redirectPath = localStorage.getItem("redirect_path");
+        if (redirectPath && redirectPath !== router.pathname) {
+          localStorage.removeItem("redirect_path");
+          router.push(redirectPath);
+          return;
+        }
       } catch (err) {
         console.error("Failed to fetch profile:", err);
         setError("Failed to load profile");

--- a/get_user_profile/pages/playlists/[id].tsx
+++ b/get_user_profile/pages/playlists/[id].tsx
@@ -3,7 +3,7 @@ import { useRouter } from "next/router";
 import { fetchPlaylist, fetchPlaylistItems } from "../api/playlist";
 import { fetchAudioFeatures } from "../api/track";
 import { PlaylistDetail } from "../../components/playlistDetail";
-import { redirectToAuthCodeFlow } from "../../../get_user_profile/src/authCodeWithPkce";
+import { redirectToAuthCodeFlow } from "../../src/authCodeWithPkce";
 
 const clientId = process.env.NEXT_PUBLIC_SPOTIFY_CLIENT_ID;
 
@@ -23,7 +23,7 @@ const PlaylistDetailPage = () => {
     const fetchData = async () => {
       const accessToken = localStorage.getItem("access_token");
       if (!accessToken) {
-        console.error("Access token not found");
+        redirectToAuthCodeFlow(clientId!);
         return;
       }
       try {
@@ -65,8 +65,7 @@ const PlaylistDetailPage = () => {
       setLoading(true);
       const storedAccessToken = localStorage.getItem("access_token");
       if (!storedAccessToken) {
-        router.push("/");
-        redirectToAuthCodeFlow(clientId);
+        redirectToAuthCodeFlow(clientId!);
       } else {
         const tracks = await fetchPlaylistItems(
           storedAccessToken,

--- a/get_user_profile/pages/playlists/index.tsx
+++ b/get_user_profile/pages/playlists/index.tsx
@@ -3,7 +3,6 @@ import { Playlists } from "../../components/playlists";
 import { fetchPlaylists } from "../../pages/api/playlist";
 import { redirectToAuthCodeFlow } from "../../src/authCodeWithPkce";
 
-import { useRouter } from "next/router";
 import { useAuth } from "../../src/AuthContext";
 
 const clientId = process.env.NEXT_PUBLIC_SPOTIFY_CLIENT_ID;
@@ -11,8 +10,7 @@ export default function PlaylistsPage() {
   const [playlists, setPlaylists] = useState<SpotifyPlaylistsResponse | null>(
     null
   );
-  const router = useRouter();
-  const { token } = useAuth();
+  const { token, setToken } = useAuth();
   const [loading, setLoading] = useState(false);
   const [offset, setOffset] = useState(0);
   const [hasMore, setHasMore] = useState(true);
@@ -21,10 +19,15 @@ export default function PlaylistsPage() {
     if (!clientId || !hasMore || loading) return;
     setLoading(true);
     try {
-      if (!token) {
-        router.push("/");
+      const storedAccessToken =
+        token ||
+        (typeof window !== "undefined"
+          ? localStorage.getItem("access_token")
+          : null);
+      if (!storedAccessToken) {
         redirectToAuthCodeFlow(clientId);
       } else {
+        if (!token) setToken(storedAccessToken);
         const playlistsData = await fetchPlaylists(
           storedAccessToken,
           50,

--- a/get_user_profile/src/authCodeWithPkce.ts
+++ b/get_user_profile/src/authCodeWithPkce.ts
@@ -3,6 +3,8 @@ export async function redirectToAuthCodeFlow(clientId: string) {
   const challenge = await generateCodeChallenge(verifier);
   try {
     localStorage.setItem("verifier", verifier);
+    const currentPath = window.location.pathname + window.location.search;
+    localStorage.setItem("redirect_path", currentPath);
   } catch (e) {
     console.warn("Failed to access localStorage", e);
   }


### PR DESCRIPTION
## Summary
- preserve current path before Spotify auth and restore it after callback
- use stored access token for playlists and playlist details
- redirect back to the page that initiated authentication

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892b8bce4b48332b0fc0c9b2bb89bd7