### PR TITLE
Handle missing followers in profile

### DIFF
--- a/get_user_profile/components/profile.tsx
+++ b/get_user_profile/components/profile.tsx
@@ -7,7 +7,7 @@ interface UserProfile {
   email: string;
   uri: string;
   external_urls: { spotify: string };
-  followers: { href: string; total: number };
+  followers?: { href: string; total: number };
   href: string;
 }
 
@@ -36,7 +36,7 @@ export const Profile: React.FC<ProfileProps> = ({ profile }) => {
         <ul className="list-none space-y-2">
           <li>User ID: {profile.id}</li>
           <li>Email: {profile.email}</li>
-          <li>Followers: {profile.followers.total}</li>
+          <li>Followers: {profile.followers?.total ?? 0}</li>
           <li>
             Spotify URI:{" "}
             <a href={profile.uri} className="text-blue-400 hover:text-blue-300">

--- a/get_user_profile/pages/api/types.d.ts
+++ b/get_user_profile/pages/api/types.d.ts
@@ -7,7 +7,7 @@ interface UserProfile {
     filter_locked: boolean;
   };
   external_urls: { spotify: string };
-  followers: { href: string; total: number };
+  followers?: { href: string; total: number };
   href: string;
   id: string;
   images: Image[];

--- a/get_user_profile/src/__tests__/profile.test.tsx
+++ b/get_user_profile/src/__tests__/profile.test.tsx
@@ -1,0 +1,43 @@
+/** @jest-environment jsdom */
+import React from "react";
+import { createRoot, Root } from "react-dom/client";
+import { act } from "react-dom/test-utils";
+import { Profile } from "../../components/profile";
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("Profile", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("renders follower count when followers data is missing", async () => {
+    const profile = {
+      display_name: "Test User",
+      images: [],
+      id: "user-id",
+      email: "test@example.com",
+      uri: "spotify:user:user-id",
+      external_urls: { spotify: "https://spotify.com" },
+      href: "https://api.spotify.com/v1/users/user-id",
+    } as any;
+
+    await act(async () => {
+      root.render(<Profile profile={profile} />);
+    });
+
+    expect(container.textContent).toContain("Followers: 0");
+  });
+});

--- a/get_user_profile/src/types.d.ts
+++ b/get_user_profile/src/types.d.ts
@@ -7,7 +7,7 @@ interface UserProfile {
     filter_locked: boolean;
   };
   external_urls: { spotify: string };
-  followers: { href: string; total: number };
+  followers?: { href: string; total: number };
   href: string;
   id: string;
   images: Image[];


### PR DESCRIPTION
## Summary
- avoid runtime error when user profile lacks follower data
- mark follower info optional across shared types
- add test ensuring profile renders without follower info

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68931ae8b6e88332a7e33060b7926179