### PR TITLE
fix: handle undefined playlist items on reload and profile link

### DIFF
--- a/get_user_profile/components/profile.tsx
+++ b/get_user_profile/components/profile.tsx
@@ -6,7 +6,7 @@ interface UserProfile {
   id: string;
   email: string;
   uri: string;
-  external_urls: { spotify: string };
+  external_urls?: { spotify: string };
   followers?: { href: string; total: number };
   href: string;
 }
@@ -43,15 +43,17 @@ export const Profile: React.FC<ProfileProps> = ({ profile }) => {
               {profile.uri}
             </a>
           </li>
-          <li>
-            Link:{" "}
-            <a
-              href={profile.external_urls.spotify}
-              className="text-blue-400 hover:text-blue-300"
-            >
-              Profile Link
-            </a>
-          </li>
+          {profile.external_urls?.spotify && (
+            <li>
+              Link:{" "}
+              <a
+                href={profile.external_urls.spotify}
+                className="text-blue-400 hover:text-blue-300"
+              >
+                Profile Link
+              </a>
+            </li>
+          )}
         </ul>
       </section>
       <section

--- a/get_user_profile/pages/playlists/index.tsx
+++ b/get_user_profile/pages/playlists/index.tsx
@@ -33,6 +33,11 @@ export default function PlaylistsPage() {
           50,
           offset
         );
+        if (!playlistsData || !Array.isArray(playlistsData.items)) {
+          console.error("Invalid playlists data:", playlistsData);
+          setHasMore(false);
+          return;
+        }
         // Deduplicate playlists by ID before updating state
         setPlaylists((prev) => {
           const existingItems = prev?.items || [];


### PR DESCRIPTION
## Summary
- guard against undefined `items` when fetching playlists to prevent reload crash
- guard against missing profile `external_urls` to avoid runtime errors

## Testing
- `npm test` *(in `get_user_profile`)*
- `npm test` *(fails: Could not read package.json at repository root)*

------
https://chatgpt.com/codex/tasks/task_e_6893351dcaa88332b15928144dcf631f