### PR TITLE
feat: make playlist detail responsive grid

### DIFF
--- a/get_user_profile/components/playlistDetail.tsx
+++ b/get_user_profile/components/playlistDetail.tsx
@@ -46,7 +46,9 @@ export const PlaylistDetail: React.FC<PlaylistDetailProps> = ({
         <h2 className="text-2xl font-bold mb-4">
           Playlist: {playlistDetail.name}
         </h2>
-        <div className="space-y-4">
+        <div
+          className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 3xl:grid-cols-7 4xl:grid-cols-8"
+        >
           {playlistDetail.tracks?.items?.map((item, index) => {
             const features = trackFeatures[item.track.id];
             return (

--- a/get_user_profile/tailwind.config.js
+++ b/get_user_profile/tailwind.config.js
@@ -2,7 +2,12 @@
 export default {
   content: ["./pages/**/*.{html,js,tsx}", "./components/**/*.{html,js,tsx}"],
   theme: {
-    extend: {},
+    extend: {
+      screens: {
+        "3xl": "1920px",
+        "4xl": "2560px",
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- display playlist tracks in a responsive grid that scales from 1 up to 8 columns
- add 3xl and 4xl screen breakpoints in Tailwind to support more columns

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689338b08ff88332a48cec8b5818a5e1