### PR TITLE
Add playlist analytics page with audio feature charts

### DIFF
--- a/get_user_profile/components/playlistDetail.tsx
+++ b/get_user_profile/components/playlistDetail.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from "react";
+import Link from "next/link";
 import { Loader } from "./loader";
 
 interface PlaylistDetailProps {
@@ -44,9 +45,17 @@ export const PlaylistDetail: React.FC<PlaylistDetailProps> = ({
         id="playlist-detail"
         className="bg-gray-800 text-white p-5 rounded-lg shadow-lg"
       >
-        <h2 className="text-2xl font-bold mb-4">
-          Playlist: {playlistDetail.name}
-        </h2>
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-2xl font-bold">
+            Playlist: {playlistDetail.name}
+          </h2>
+          <Link
+            href={`/playlists/${playlistDetail.id}/analytics`}
+            className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded"
+          >
+            Analytics
+          </Link>
+        </div>
         <div
           className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 3xl:grid-cols-7 4xl:grid-cols-8"
         >

--- a/get_user_profile/package-lock.json
+++ b/get_user_profile/package-lock.json
@@ -8,9 +8,11 @@
       "name": "vite-project",
       "version": "0.0.0",
       "dependencies": {
+        "chart.js": "^4.4.1",
         "dotenv": "^16.4.5",
         "next": "^14.1.4",
         "react": "^18.2.0",
+        "react-chartjs-2": "^5.2.0",
         "react-dom": "^18.2.0",
         "react-loader-spinner": "^6.1.6"
       },
@@ -1600,6 +1602,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -2730,6 +2738,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/chokidar": {
@@ -5459,6 +5479,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/get_user_profile/package.json
+++ b/get_user_profile/package.json
@@ -24,10 +24,12 @@
   },
   "dependencies": {
     "dotenv": "^16.4.5",
+    "chart.js": "^4.4.1",
     "next": "^14.1.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-loader-spinner": "^6.1.6"
+    "react-loader-spinner": "^6.1.6",
+    "react-chartjs-2": "^5.2.0"
   },
   "jest": {
     "preset": "ts-jest/presets/default-esm",

--- a/get_user_profile/pages/api/playlist.ts
+++ b/get_user_profile/pages/api/playlist.ts
@@ -1,4 +1,3 @@
-import { useRouter } from "next/router";
 export const fetchPlaylists = async (
   code: string,
   limit: number,

--- a/get_user_profile/pages/api/profile.ts
+++ b/get_user_profile/pages/api/profile.ts
@@ -1,4 +1,3 @@
-import { useRouter } from "next/router";
 export const fetchProfile = async (code: string): Promise<UserProfile> => {
   const result = await fetch("https://api.spotify.com/v1/me", {
     method: "GET",

--- a/get_user_profile/pages/api/track.ts
+++ b/get_user_profile/pages/api/track.ts
@@ -14,3 +14,24 @@ export const fetchAudioFeatures = async (
   }
   return await response.json();
 };
+
+export const fetchAudioFeaturesBatch = async (
+  accessToken: string,
+  trackIds: string[]
+): Promise<SpotifyAudioFeaturesResponse[]> => {
+  const response = await fetch(
+    `https://api.spotify.com/v1/audio-features?ids=${trackIds.join(",")}`,
+    {
+      method: "GET",
+      headers: { Authorization: `Bearer ${accessToken}` },
+    }
+  );
+  if (!response.ok) {
+    throw new Error("Failed to fetch audio features");
+  }
+  const data = await response.json();
+  return (data.audio_features || []).filter(
+    (f: SpotifyAudioFeaturesResponse | null): f is SpotifyAudioFeaturesResponse =>
+      f !== null
+  );
+};

--- a/get_user_profile/pages/playlists/[id]/analytics.tsx
+++ b/get_user_profile/pages/playlists/[id]/analytics.tsx
@@ -1,0 +1,154 @@
+import React, { useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import {
+  fetchPlaylist,
+  fetchPlaylistItems,
+} from "../../api/playlist";
+import { fetchAudioFeaturesBatch } from "../../api/track";
+import { redirectToAuthCodeFlow } from "../../../src/authCodeWithPkce";
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from "chart.js";
+import { Bar } from "react-chartjs-2";
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
+
+const clientId = process.env.NEXT_PUBLIC_SPOTIFY_CLIENT_ID;
+
+const featureDefinitions: { key: keyof SpotifyAudioFeaturesResponse; label: string }[] = [
+  { key: "danceability", label: "Danceability" },
+  { key: "energy", label: "Energy" },
+  { key: "acousticness", label: "Acousticness" },
+  { key: "instrumentalness", label: "Instrumentalness" },
+  { key: "liveness", label: "Liveness" },
+  { key: "speechiness", label: "Speechiness" },
+  { key: "valence", label: "Valence" },
+];
+
+const getHistogramData = (values: number[], bins = 10) => {
+  const counts = new Array(bins).fill(0);
+  values.forEach((v) => {
+    const idx = Math.min(Math.floor(v * bins), bins - 1);
+    counts[idx] += 1;
+  });
+  return {
+    labels: counts.map((_, i) => `${(i / bins).toFixed(1)}-${((i + 1) / bins).toFixed(1)}`),
+    datasets: [
+      {
+        label: "Tracks",
+        data: counts,
+        backgroundColor: "rgba(59,130,246,0.5)",
+      },
+    ],
+  };
+};
+
+const AnalyticsPage = () => {
+  const router = useRouter();
+  const { id } = router.query;
+  const playlistId = typeof id === "string" ? id : undefined;
+
+  const [playlist, setPlaylist] = useState<SpotifyPlaylistResponse | null>(null);
+  const [features, setFeatures] = useState<SpotifyAudioFeaturesResponse[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const loadInitial = async () => {
+    const accessToken = localStorage.getItem("access_token");
+    if (!accessToken) {
+      redirectToAuthCodeFlow(clientId!);
+      return;
+    }
+    if (!playlistId) return;
+    try {
+      const playlistData = await fetchPlaylist(accessToken, playlistId, 50, 0);
+      setPlaylist(playlistData);
+      const ids =
+        playlistData.tracks?.items?.map((item) => item.track.id) ?? [];
+      if (ids.length > 0) {
+        const feats = await fetchAudioFeaturesBatch(accessToken, ids);
+        setFeatures(feats);
+      }
+    } catch (e) {
+      console.error("Failed to load analytics", e);
+    }
+  };
+
+  useEffect(() => {
+    if (playlistId) {
+      loadInitial();
+    }
+  }, [playlistId]);
+
+  const handleLoadMore = async () => {
+    if (loading || !playlist?.tracks?.next) return;
+    const accessToken = localStorage.getItem("access_token");
+    if (!accessToken) {
+      redirectToAuthCodeFlow(clientId!);
+      return;
+    }
+    setLoading(true);
+    try {
+      const tracks = await fetchPlaylistItems(accessToken, playlist.tracks.next);
+      const uniqueItems = tracks.items.filter(
+        (item) =>
+          !playlist.tracks!.items.some(
+            (existing) => existing.track.id === item.track.id
+          )
+      );
+      setPlaylist((prev) =>
+        prev && prev.tracks
+          ? {
+              ...prev,
+              tracks: {
+                ...prev.tracks,
+                items: [...prev.tracks.items, ...uniqueItems],
+                next: tracks.next,
+                previous: tracks.previous,
+              },
+            }
+          : prev
+      );
+      const ids = uniqueItems.map((item) => item.track.id);
+      if (ids.length > 0) {
+        const feats = await fetchAudioFeaturesBatch(accessToken, ids);
+        setFeatures((prev) => [...prev, ...feats]);
+      }
+    } catch (e) {
+      console.error("Failed to load more tracks", e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <section className="bg-gray-800 text-white p-5 rounded-lg shadow-lg">
+      <h2 className="text-2xl font-bold mb-4">Analytics: {playlist?.name}</h2>
+      {features.length > 0 && (
+        <div className="space-y-8">
+          {featureDefinitions.map((f) => (
+            <div key={f.key}>
+              <h3 className="mb-2 font-semibold">{f.label}</h3>
+              <Bar data={getHistogramData(features.map((feat) => feat[f.key] as number))} />
+            </div>
+          ))}
+        </div>
+      )}
+      {playlist?.tracks?.next && (
+        <button
+          onClick={handleLoadMore}
+          className="mt-4 bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded"
+        >
+          {loading ? "Loading..." : "Load more..."}
+        </button>
+      )}
+    </section>
+  );
+};
+
+export default AnalyticsPage;

--- a/get_user_profile/pages/playlists/[id]/index.tsx
+++ b/get_user_profile/pages/playlists/[id]/index.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from "react";
 import { useRouter } from "next/router";
-import { fetchPlaylist, fetchPlaylistItems } from "../api/playlist";
-import { fetchAudioFeatures } from "../api/track";
-import { PlaylistDetail } from "../../components/playlistDetail";
-import { Loader } from "../../components/loader";
-import { redirectToAuthCodeFlow } from "../../src/authCodeWithPkce";
+import { fetchPlaylist, fetchPlaylistItems } from "../../api/playlist";
+import { fetchAudioFeatures } from "../../api/track";
+import { PlaylistDetail } from "../../../components/playlistDetail";
+import { Loader } from "../../../components/loader";
+import { redirectToAuthCodeFlow } from "../../../src/authCodeWithPkce";
 
 const clientId = process.env.NEXT_PUBLIC_SPOTIFY_CLIENT_ID;
 

--- a/get_user_profile/tsconfig.json
+++ b/get_user_profile/tsconfig.json
@@ -20,6 +20,6 @@
     "jsx": "preserve",
     "sourceMap": true
   },
-  "include": ["src"],
+  "include": ["src", "pages", "components"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- add Analytics link to playlist pages
- plot audio feature distributions with Chart.js and support loading more tracks
- batch fetch audio features for multiple tracks

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68933c5a984483328890ed617d69dfe9