### PR TITLE
Add automatic Spotify token refresh support

### DIFF
--- a/get_user_profile/pages/index.tsx
+++ b/get_user_profile/pages/index.tsx
@@ -39,12 +39,16 @@ export default function Home() {
         return;
       }
       try {
-        const accessToken = await getAccessToken(clientId, code);
-        if (!accessToken) {
+        const tokenData = await getAccessToken(clientId, code);
+        if (!tokenData || !tokenData.access_token) {
           redirectToAuthCodeFlow(clientId);
           return;
         }
-        setToken(accessToken);
+        setToken(
+          tokenData.access_token,
+          tokenData.refresh_token,
+          tokenData.expires_in
+        );
         const redirectPath = localStorage.getItem("redirect_path");
         if (redirectPath && redirectPath !== router.pathname) {
           localStorage.removeItem("redirect_path");

--- a/get_user_profile/src/AuthContext.tsx
+++ b/get_user_profile/src/AuthContext.tsx
@@ -1,8 +1,14 @@
 import React, { createContext, useContext, useEffect, useState } from "react";
+import { refreshAccessToken } from "./authCodeWithPkce";
 
 interface AuthContextType {
   token: string | null;
-  setToken: (token: string | null) => void;
+  refreshToken: string | null;
+  setToken: (
+    token: string | null,
+    refreshToken?: string | null,
+    expiresIn?: number
+  ) => void;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -11,37 +17,93 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const [token, setTokenState] = useState<string | null>(null);
+  const [refreshToken, setRefreshTokenState] = useState<string | null>(null);
+  const [expiresAt, setExpiresAt] = useState<number | null>(null);
 
-  // Load token from localStorage on initial mount
+  // Load tokens from localStorage on initial mount
   useEffect(() => {
     if (typeof window === "undefined") return;
     try {
       const stored = window.localStorage.getItem("access_token");
+      const storedRefresh = window.localStorage.getItem("refresh_token");
+      const storedExpires = window.localStorage.getItem("expires_at");
       if (stored) {
         setTokenState(stored);
+      }
+      if (storedRefresh) {
+        setRefreshTokenState(storedRefresh);
+      }
+      if (storedExpires) {
+        setExpiresAt(parseInt(storedExpires, 10));
       }
     } catch (e) {
       console.warn("Failed to read access token from localStorage", e);
     }
   }, []);
 
-  const setToken = (newToken: string | null) => {
+  // Automatically refresh the access token before it expires
+  useEffect(() => {
+    if (!token || !refreshToken || !expiresAt) return;
+    const clientId = process.env.NEXT_PUBLIC_SPOTIFY_CLIENT_ID;
+    if (!clientId) return;
+    const timeout = setTimeout(async () => {
+      try {
+        const data = await refreshAccessToken(clientId, refreshToken);
+        if (data?.access_token && data?.expires_in) {
+          setToken(data.access_token, refreshToken, data.expires_in);
+        }
+      } catch (e) {
+        console.warn("Failed to refresh access token", e);
+        setToken(null, null);
+      }
+    }, Math.max(0, expiresAt - Date.now() - 60000));
+    return () => clearTimeout(timeout);
+  }, [token, refreshToken, expiresAt]);
+
+  const setToken = (
+    newToken: string | null,
+    newRefreshToken?: string | null,
+    expiresIn?: number
+  ) => {
     if (typeof window !== "undefined") {
       try {
         if (newToken) {
           window.localStorage.setItem("access_token", newToken);
+          if (newRefreshToken !== undefined) {
+            if (newRefreshToken) {
+              window.localStorage.setItem("refresh_token", newRefreshToken);
+            } else {
+              window.localStorage.removeItem("refresh_token");
+            }
+          }
+          if (expiresIn !== undefined) {
+            const exp = Date.now() + expiresIn * 1000;
+            window.localStorage.setItem("expires_at", exp.toString());
+            setExpiresAt(exp);
+          }
         } else {
           window.localStorage.removeItem("access_token");
+          window.localStorage.removeItem("refresh_token");
+          window.localStorage.removeItem("expires_at");
+          setRefreshTokenState(null);
+          setExpiresAt(null);
         }
       } catch (e) {
         console.warn("Failed to write access token to localStorage", e);
       }
     }
     setTokenState(newToken);
+    if (newRefreshToken !== undefined) {
+      setRefreshTokenState(newRefreshToken);
+    }
+    if (expiresIn !== undefined && newToken) {
+      const exp = Date.now() + expiresIn * 1000;
+      setExpiresAt(exp);
+    }
   };
 
   return (
-    <AuthContext.Provider value={{ token, setToken }}>
+    <AuthContext.Provider value={{ token, refreshToken, setToken }}>
       {children}
     </AuthContext.Provider>
   );

--- a/get_user_profile/src/authCodeWithPkce.ts
+++ b/get_user_profile/src/authCodeWithPkce.ts
@@ -48,15 +48,40 @@ export async function getAccessToken(clientId: string, code: string) {
     body: params,
   });
 
-  const { access_token } = await result.json();
+  const { access_token, refresh_token, expires_in } = await result.json();
   if (access_token) {
     try {
       localStorage.setItem("access_token", access_token);
+      if (refresh_token) {
+        localStorage.setItem("refresh_token", refresh_token);
+      }
+      if (expires_in) {
+        const expiresAt = (Date.now() + expires_in * 1000).toString();
+        localStorage.setItem("expires_at", expiresAt);
+      }
     } catch (e) {
       console.warn("Failed to access localStorage", e);
     }
   }
-  return access_token || null;
+  return { access_token, refresh_token, expires_in };
+}
+
+export async function refreshAccessToken(
+  clientId: string,
+  refreshToken: string
+) {
+  const params = new URLSearchParams();
+  params.append("client_id", clientId);
+  params.append("grant_type", "refresh_token");
+  params.append("refresh_token", refreshToken);
+
+  const result = await fetch("https://accounts.spotify.com/api/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: params,
+  });
+
+  return await result.json();
 }
 
 export function generateCodeVerifier(length: number) {

--- a/get_user_profile/src/script.ts
+++ b/get_user_profile/src/script.ts
@@ -1,23 +1,83 @@
 // Because this is a literal single page application
 // we detect a callback from Spotify by checking for the hash fragment
-import { redirectToAuthCodeFlow, getAccessToken } from "./authCodeWithPkce";
+import {
+  redirectToAuthCodeFlow,
+  getAccessToken,
+  refreshAccessToken,
+} from "./authCodeWithPkce";
 
 const clientId = import.meta.env.VITE_SPOTIFY_CLIENT_ID;
 const params = new URLSearchParams(window.location.search);
 const code = params.get("code");
 
-if (!code) {
+if (code) {
+  const tokenData = await getAccessToken(clientId, code);
+  if (tokenData?.access_token) {
+    try {
+      localStorage.setItem("access_token", tokenData.access_token);
+      if (tokenData.refresh_token) {
+        localStorage.setItem("refresh_token", tokenData.refresh_token);
+      }
+      if (tokenData.expires_in) {
+        const exp = (Date.now() + tokenData.expires_in * 1000).toString();
+        localStorage.setItem("expires_at", exp);
+      }
+    } catch (e) {
+      console.warn("Failed to write tokens to localStorage", e);
+    }
+  }
+}
+
+const accessToken = await getStoredAccessToken();
+if (!accessToken) {
   redirectToAuthCodeFlow(clientId);
 } else {
-  const accessToken = await getAccessToken(clientId, code);
   const profile = await fetchProfile(accessToken);
   populateUI(profile);
 }
 
-async function fetchProfile(code: string): Promise<UserProfile> {
+async function getStoredAccessToken(): Promise<string | null> {
+  try {
+    const token = localStorage.getItem("access_token");
+    const refreshToken = localStorage.getItem("refresh_token");
+    const expires = localStorage.getItem("expires_at");
+    if (!token) return null;
+
+    if (expires) {
+      const expiresAt = parseInt(expires, 10);
+      // refresh if the token is expired or will expire within the next minute
+      if (expiresAt - Date.now() < 60_000) {
+        if (!refreshToken) return null;
+        try {
+          const refreshed = await refreshAccessToken(clientId, refreshToken);
+          if (!refreshed?.access_token) return null;
+          localStorage.setItem("access_token", refreshed.access_token);
+          if (refreshed.refresh_token) {
+            localStorage.setItem("refresh_token", refreshed.refresh_token);
+          }
+          if (refreshed.expires_in) {
+            const newExp = (Date.now() + refreshed.expires_in * 1000).toString();
+            localStorage.setItem("expires_at", newExp);
+          }
+          return refreshed.access_token;
+        } catch (e) {
+          console.warn("Failed to refresh access token", e);
+          return null;
+        }
+      }
+    }
+
+    return token;
+  } catch (e) {
+    console.warn("Failed to read tokens from localStorage", e);
+    return null;
+  }
+}
+
+async function fetchProfile(token: string): Promise<UserProfile> {
   const result = await fetch("https://api.spotify.com/v1/me", {
     method: "GET",
-    headers: { Authorization: `Bearer ${code}` },
+    headers: { Authorization: `Bearer ${token}` },
   });
 
   return await result.json();


### PR DESCRIPTION
## Summary
- persist access, refresh, and expiration tokens in localStorage after code exchange
- refresh expired or soon-to-expire access tokens before API calls
- load access token from storage when fetching user profile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897c2a598388332adc2f5966bd80d6f