### PR TITLE
Allow optional device ID in web player controls

### DIFF
--- a/get_user_profile/pages/api/player.ts
+++ b/get_user_profile/pages/api/player.ts
@@ -34,7 +34,7 @@ export const fetchAvailableDevices = async (code: string): Promise<any[]> => {
 
 export const startPlayback = async (
   token: string,
-  deviceId: string,
+  deviceId?: string,
   contextUri: string,
   offset: number
 ): Promise<void> => {
@@ -58,7 +58,7 @@ export const startPlayback = async (
 
 export const pausePlayback = async (
   token: string,
-  deviceId: string
+  deviceId?: string
 ): Promise<void> => {
   await fetch(
     `https://api.spotify.com/v1/me/player/pause${
@@ -73,7 +73,7 @@ export const pausePlayback = async (
 
 export const nextTrack = async (
   token: string,
-  deviceId: string
+  deviceId?: string
 ): Promise<void> => {
   await fetch(
     `https://api.spotify.com/v1/me/player/next${
@@ -88,7 +88,7 @@ export const nextTrack = async (
 
 export const previousTrack = async (
   token: string,
-  deviceId: string
+  deviceId?: string
 ): Promise<void> => {
   await fetch(
     `https://api.spotify.com/v1/me/player/previous${

--- a/get_user_profile/pages/web-player.tsx
+++ b/get_user_profile/pages/web-player.tsx
@@ -96,12 +96,17 @@ export default function WebPlayerPage() {
     selected?.tracks?.items[currentTrackIndex]?.track ?? null;
 
   const togglePlay = async () => {
-    if (!token || !selected || !deviceId) return;
+    if (!token || !selected) return;
     if (isPlaying) {
-      await pausePlayback(token, deviceId);
+      await pausePlayback(token, deviceId ?? undefined);
       setIsPlaying(false);
     } else {
-      await startPlayback(token, deviceId, selected.uri, currentTrackIndex);
+      await startPlayback(
+        token,
+        deviceId ?? undefined,
+        selected.uri,
+        currentTrackIndex
+      );
       setIsPlaying(true);
     }
   };
@@ -117,15 +122,15 @@ export default function WebPlayerPage() {
   };
 
   const playNext = async () => {
-    if (!token || !selected?.tracks || !deviceId) return;
-    await nextTrack(token, deviceId);
+    if (!token || !selected?.tracks) return;
+    await nextTrack(token, deviceId ?? undefined);
     setCurrentTrackIndex(findPlayableIndex(currentTrackIndex, 1));
     setIsPlaying(true);
   };
 
   const playPrev = async () => {
-    if (!token || !selected?.tracks || !deviceId) return;
-    await previousTrack(token, deviceId);
+    if (!token || !selected?.tracks) return;
+    await previousTrack(token, deviceId ?? undefined);
     setCurrentTrackIndex(findPlayableIndex(currentTrackIndex, -1));
     setIsPlaying(true);
   };
@@ -133,8 +138,8 @@ export default function WebPlayerPage() {
   const closePlayer = async () => {
     setSelected(null);
     setIsPlaying(false);
-    if (token && deviceId) {
-      await pausePlayback(token, deviceId);
+    if (token) {
+      await pausePlayback(token, deviceId ?? undefined);
     }
   };
 

--- a/get_user_profile/src/__tests__/authCodeWithPkce.test.ts
+++ b/get_user_profile/src/__tests__/authCodeWithPkce.test.ts
@@ -1,7 +1,9 @@
 import { generateCodeVerifier, generateCodeChallenge } from "../authCodeWithPkce";
 
 beforeAll(() => {
-  (global as any).window = { crypto: global.crypto };
+  const webcrypto = require("crypto").webcrypto;
+  (global as any).crypto = webcrypto;
+  (global as any).window = { crypto: webcrypto };
 });
 
 describe("generateCodeVerifier", () => {


### PR DESCRIPTION
## Summary
- allow player control API functions to accept undefined device IDs
- update web player controls to work without specifying a device ID
- polyfill crypto in PKCE tests for Node environment

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897cd3554ec833293c8df01f4c561c2