### PR TITLE
feat: enhance web player

### DIFF
--- a/get_user_profile/components/webPlayer.tsx
+++ b/get_user_profile/components/webPlayer.tsx
@@ -5,7 +5,7 @@ import { PlaylistList } from "./playlistList";
 interface WebPlayerProps {
   playlists: SpotifyPlaylistsResponse;
   selected: SpotifyPlaylistResponse | null;
-  currentTrack: SpotifyTrack | null;
+  currentTrack: SpotifyTrackObject | null;
   isPlaying: boolean;
   controlsDisabled: boolean;
   deviceError: string | null;
@@ -16,6 +16,15 @@ interface WebPlayerProps {
   onSelectPlaylist: (
     pl: SpotifyPlaylistsResponse["items"][number]
   ) => void;
+  position: number;
+  duration: number;
+  volume: number;
+  shuffle: boolean;
+  repeat: "off" | "track" | "context";
+  onSeek: (ms: number) => void;
+  onVolumeChange: (v: number) => void;
+  onToggleShuffle: () => void;
+  onToggleRepeat: () => void;
 }
 
 /**
@@ -35,6 +44,15 @@ export const WebPlayer: React.FC<WebPlayerProps> = ({
   onNext,
   onClose,
   onSelectPlaylist,
+  position,
+  duration,
+  volume,
+  shuffle,
+  repeat,
+  onSeek,
+  onVolumeChange,
+  onToggleShuffle,
+  onToggleRepeat,
 }) => (
   <div className="relative text-white">
     <Player
@@ -46,6 +64,15 @@ export const WebPlayer: React.FC<WebPlayerProps> = ({
       onPrev={onPrev}
       onNext={onNext}
       onClose={onClose}
+      position={position}
+      duration={duration}
+      volume={volume}
+      shuffle={shuffle}
+      repeat={repeat}
+      onSeek={onSeek}
+      onVolumeChange={onVolumeChange}
+      onToggleShuffle={onToggleShuffle}
+      onToggleRepeat={onToggleRepeat}
     />
     {deviceError && (
       <p className="text-center text-red-500 mt-4">{deviceError}</p>

--- a/get_user_profile/pages/api/player.ts
+++ b/get_user_profile/pages/api/player.ts
@@ -1,17 +1,3 @@
-const fetchWithRetry = async (
-  url: string,
-  options: RequestInit,
-  retries = 3
-): Promise<Response> => {
-  for (let i = 0; i < retries; i++) {
-    const res = await fetch(url, options);
-    if (res.ok || res.status === 204) {
-      return res;
-    }
-  }
-  throw new Error(`Request failed after ${retries} attempts`);
-};
-
 export const fetchPlayerState = async (code: string): Promise<any | null> => {
   const res = await fetch("https://api.spotify.com/v1/me/player", {
     method: "GET",
@@ -34,9 +20,9 @@ export const fetchAvailableDevices = async (code: string): Promise<any[]> => {
 
 export const startPlayback = async (
   token: string,
-  deviceId?: string,
   contextUri: string,
-  offset: number
+  offset: number,
+  deviceId?: string
 ): Promise<void> => {
   await fetch(
     `https://api.spotify.com/v1/me/player/play${
@@ -96,6 +82,70 @@ export const previousTrack = async (
     }`,
     {
       method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+    }
+  );
+};
+
+export const seekPlayback = async (
+  token: string,
+  positionMs: number,
+  deviceId?: string
+): Promise<void> => {
+  await fetch(
+    `https://api.spotify.com/v1/me/player/seek?position_ms=${positionMs}${
+      deviceId ? `&device_id=${deviceId}` : ""
+    }`,
+    {
+      method: "PUT",
+      headers: { Authorization: `Bearer ${token}` },
+    }
+  );
+};
+
+export const setVolume = async (
+  token: string,
+  volumePercent: number,
+  deviceId?: string
+): Promise<void> => {
+  await fetch(
+    `https://api.spotify.com/v1/me/player/volume?volume_percent=${volumePercent}${
+      deviceId ? `&device_id=${deviceId}` : ""
+    }`,
+    {
+      method: "PUT",
+      headers: { Authorization: `Bearer ${token}` },
+    }
+  );
+};
+
+export const setShuffle = async (
+  token: string,
+  state: boolean,
+  deviceId?: string
+): Promise<void> => {
+  await fetch(
+    `https://api.spotify.com/v1/me/player/shuffle?state=${state}${
+      deviceId ? `&device_id=${deviceId}` : ""
+    }`,
+    {
+      method: "PUT",
+      headers: { Authorization: `Bearer ${token}` },
+    }
+  );
+};
+
+export const setRepeat = async (
+  token: string,
+  state: "off" | "track" | "context",
+  deviceId?: string
+): Promise<void> => {
+  await fetch(
+    `https://api.spotify.com/v1/me/player/repeat?state=${state}${
+      deviceId ? `&device_id=${deviceId}` : ""
+    }`,
+    {
+      method: "PUT",
       headers: { Authorization: `Bearer ${token}` },
     }
   );

--- a/get_user_profile/pages/web-player.tsx
+++ b/get_user_profile/pages/web-player.tsx
@@ -11,6 +11,10 @@ import {
   pausePlayback,
   nextTrack,
   previousTrack,
+  seekPlayback,
+  setVolume as apiSetVolume,
+  setShuffle as apiSetShuffle,
+  setRepeat as apiSetRepeat,
 } from "./api/player";
 import { redirectToAuthCodeFlow } from "../src/authCodeWithPkce";
 import { WebPlayer } from "../components/webPlayer";
@@ -29,7 +33,15 @@ export default function WebPlayerPage() {
   const [isPlaying, setIsPlaying] = useState(false);
   const [deviceId, setDeviceId] = useState<string | null>(null);
   const [deviceError, setDeviceError] = useState<string | null>(null);
-  const [controlsDisabled, setControlsDisabled] = useState(false);
+  const controlsDisabled = !deviceId;
+  const [sdkPlayer, setSdkPlayer] = useState<any | null>(null);
+  const [position, setPosition] = useState(0);
+  const [duration, setDuration] = useState(0);
+  const [volume, setVolume] = useState(1);
+  const [shuffle, setShuffleState] = useState(false);
+  const [repeat, setRepeatState] = useState<"off" | "track" | "context">(
+    "off"
+  );
 
   useEffect(() => {
     const fetchData = async () => {
@@ -52,35 +64,59 @@ export default function WebPlayerPage() {
 
   useEffect(() => {
     if (!token) return;
-    let attempts = 0;
-    let interval: NodeJS.Timeout;
-
     const updatePlayback = async () => {
       const data = await fetchPlayerState(token);
-      if (!data || !data.device) {
-        setDeviceError(
-          "No active Spotify device found. Please open Spotify on a device."
-        );
-        setDeviceId(null);
-        setIsPlaying(false);
-        // setControlsDisabled(true);
-        attempts++;
-        if (attempts >= 3) {
-          clearInterval(interval);
-        }
-        return;
-      }
-      setDeviceId(data.device.id);
+      if (!data) return;
+      if (data.device) setDeviceId(data.device.id);
       setIsPlaying(data.is_playing);
-      setDeviceError(null);
-      // setControlsDisabled(false);
-      attempts = 0;
+      setPosition(data.progress_ms ?? 0);
+      setDuration(data.item?.duration_ms ?? 0);
+      setShuffleState(data.shuffle_state ?? false);
+      setRepeatState(data.repeat_state ?? "off");
     };
-
     updatePlayback();
-    interval = setInterval(updatePlayback, 5000);
+    const interval = setInterval(updatePlayback, 5000);
     return () => clearInterval(interval);
   }, [token]);
+
+  useEffect(() => {
+    if (!token || sdkPlayer) return;
+    const script = document.createElement("script");
+    script.src = "https://sdk.scdn.co/spotify-player.js";
+    script.async = true;
+    document.body.appendChild(script);
+    let player: any;
+    (window as any).onSpotifyWebPlaybackSDKReady = () => {
+      player = new (window as any).Spotify.Player({
+        name: "Web Playback",
+        getOAuthToken: (cb: any) => cb(token),
+      });
+      player.addListener("ready", ({ device_id }: any) => {
+        setDeviceId(device_id);
+        setDeviceError(null);
+        player.getVolume().then((v: number) => setVolume(v));
+      });
+      player.addListener("player_state_changed", (state: any) => {
+        if (!state) return;
+        setIsPlaying(!state.paused);
+        setPosition(state.position);
+        setDuration(state.duration);
+        setShuffleState(state.shuffle);
+        const map: Record<number, "off" | "track" | "context"> = {
+          0: "off",
+          1: "track",
+          2: "context",
+        };
+        setRepeatState(map[state.repeat_mode] || "off");
+      });
+      player.connect();
+      setSdkPlayer(player);
+    };
+    return () => {
+      if (player) player.disconnect();
+      document.body.removeChild(script);
+    };
+  }, [token, sdkPlayer]);
 
   const openPlaylist = async (pl: SpotifyPlaylistResponse) => {
     if (!token) return;
@@ -101,11 +137,12 @@ export default function WebPlayerPage() {
       await pausePlayback(token, deviceId ?? undefined);
       setIsPlaying(false);
     } else {
+      await sdkPlayer?.activateElement?.();
       await startPlayback(
         token,
-        deviceId ?? undefined,
         selected.uri,
-        currentTrackIndex
+        currentTrackIndex,
+        deviceId ?? undefined
       );
       setIsPlaying(true);
     }
@@ -135,6 +172,39 @@ export default function WebPlayerPage() {
     setIsPlaying(true);
   };
 
+  const handleSeek = async (ms: number) => {
+    if (!token) return;
+    await seekPlayback(token, ms, deviceId ?? undefined);
+    if (sdkPlayer) await sdkPlayer.seek(ms);
+    setPosition(ms);
+  };
+
+  const handleVolumeChange = async (v: number) => {
+    if (!token || !sdkPlayer) return;
+    setVolume(v);
+    await sdkPlayer.setVolume(v);
+    await apiSetVolume(token, Math.round(v * 100), deviceId ?? undefined);
+  };
+
+  const toggleShuffle = async () => {
+    if (!token) return;
+    const newState = !shuffle;
+    await apiSetShuffle(token, newState, deviceId ?? undefined);
+    setShuffleState(newState);
+  };
+
+  const cycleRepeat = async () => {
+    if (!token) return;
+    const modes: Array<"off" | "context" | "track"> = [
+      "off",
+      "context",
+      "track",
+    ];
+    const next = modes[(modes.indexOf(repeat) + 1) % modes.length];
+    await apiSetRepeat(token, next, deviceId ?? undefined);
+    setRepeatState(next);
+  };
+
   const closePlayer = async () => {
     setSelected(null);
     setIsPlaying(false);
@@ -159,6 +229,15 @@ export default function WebPlayerPage() {
       onNext={playNext}
       onClose={closePlayer}
       onSelectPlaylist={openPlaylist}
+      position={position}
+      duration={duration}
+      volume={volume}
+      shuffle={shuffle}
+      repeat={repeat}
+      onSeek={handleSeek}
+      onVolumeChange={handleVolumeChange}
+      onToggleShuffle={toggleShuffle}
+      onToggleRepeat={cycleRepeat}
     />
   );
 }


### PR DESCRIPTION
## Summary
- support playback in the browser with the Spotify Web Playback SDK
- add seekbar, volume, shuffle and repeat controls
- clamp slider values, add ARIA labels and honor disabled state
- update player tests for slider behavior

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897d154ee04833298ba7218df0399d9