### PR TITLE
feat: integrate Spotify Web Playback SDK

### DIFF
--- a/get_user_profile/src/types.d.ts
+++ b/get_user_profile/src/types.d.ts
@@ -29,3 +29,8 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+interface Window {
+  onSpotifyWebPlaybackSDKReady?: () => void;
+  Spotify: any;
+}


### PR DESCRIPTION
## Summary
- load Spotify Web Playback SDK in web player page
- register browser as playback device and activate element on user interaction
- add type declarations for SDK globals

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898644871408332a1bc7284eab1b62c