### PR TITLE
fix: keep web player active

### DIFF
--- a/get_user_profile/pages/api/player.ts
+++ b/get_user_profile/pages/api/player.ts
@@ -60,9 +60,19 @@ export const resumePlayback = async (
   );
 };
 
+/**
+ * Transfer playback to a specific device.
+ *
+ * @param token OAuth access token used for authorization.
+ * @param deviceId The target device's Spotify ID.
+ * @param play Whether playback should start on the new device. Defaults to `false`,
+ *             leaving playback paused after transfer. Set to `true` to resume
+ *             playback immediately on the new device.
+ */
 export const transferPlayback = async (
   token: string,
-  deviceId: string
+  deviceId: string,
+  play = false
 ): Promise<void> => {
   await fetch("https://api.spotify.com/v1/me/player", {
     method: "PUT",
@@ -70,7 +80,7 @@ export const transferPlayback = async (
       Authorization: `Bearer ${token}`,
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ device_ids: [deviceId], play: false }),
+    body: JSON.stringify({ device_ids: [deviceId], play }),
   });
 };
 

--- a/get_user_profile/pages/web-player.tsx
+++ b/get_user_profile/pages/web-player.tsx
@@ -113,7 +113,12 @@ export default function WebPlayerPage() {
     if (!token || !deviceId) return;
     const updatePlayback = async () => {
       const data = await fetchPlayerState(token);
-      if (!data || data.device?.id !== deviceId) return;
+      if (!data) return;
+      if (data.device?.id !== deviceId) {
+        deviceActiveRef.current = false;
+        await transferPlayback(token, deviceId, data.is_playing ?? false);
+        return;
+      }
       deviceActiveRef.current = true;
       setVolume((data.device.volume_percent ?? 100) / 100);
       setShuffleState(data.shuffle_state ?? false);


### PR DESCRIPTION
## Summary
- ensure web player stays the active device and continues playback
- allow specifying whether playback should resume when transferring devices
- document `transferPlayback` `play` parameter and its default behavior

## Testing
- `cd get_user_profile && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898a8ba01848332af5639eee9658870