### PR TITLE
fix: improve error handling and effect dependencies

### DIFF
--- a/authorization/client_credentials/app.js
+++ b/authorization/client_credentials/app.js
@@ -21,6 +21,9 @@ async function getToken() {
       'Authorization': 'Basic ' + (Buffer.from(client_id + ':' + client_secret).toString('base64')),
     },
   });
+  if (!response.ok) {
+    throw new Error(`Token request failed: ${response.status} ${response.statusText}`);
+  }
 
   return await response.json();
 }
@@ -30,12 +33,18 @@ async function getTrackInfo(access_token) {
     method: 'GET',
     headers: { 'Authorization': 'Bearer ' + access_token },
   });
+  if (!response.ok) {
+    throw new Error(`Track request failed: ${response.status} ${response.statusText}`);
+  }
 
   return await response.json();
 }
 
-getToken().then(response => {
-  getTrackInfo(response.access_token).then(profile => {
+getToken()
+  .then(response => getTrackInfo(response.access_token))
+  .then(profile => {
     console.log(profile)
   })
-});
+  .catch(err => {
+    console.error('Error fetching data:', err);
+  });

--- a/get_user_profile/pages/api/profile.ts
+++ b/get_user_profile/pages/api/profile.ts
@@ -1,7 +1,12 @@
-export const fetchProfile = async (code: string): Promise<UserProfile> => {
-  const result = await fetch("https://api.spotify.com/v1/me", {
+export const fetchProfile = async (token: string): Promise<UserProfile> => {
+  const response = await fetch("https://api.spotify.com/v1/me", {
     method: "GET",
-    headers: { Authorization: `Bearer ${code}` },
+    headers: { Authorization: `Bearer ${token}` },
   });
-  return await result.json();
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch profile: ${response.status} ${response.statusText}`);
+  }
+
+  return await response.json();
 };

--- a/get_user_profile/pages/index.tsx
+++ b/get_user_profile/pages/index.tsx
@@ -62,7 +62,7 @@ export default function Home() {
     };
 
     fetchData();
-  }, [token]);
+  }, [token, router, setToken]);
 
   if (error) {
     return <div>{error}</div>;


### PR DESCRIPTION
## Summary
- rename `fetchProfile` argument to token and handle HTTP errors
- ensure home page effect reacts to router and token updates
- check fetch responses in client credentials demo and surface failures

## Testing
- `cd get_user_profile && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898b866a3448332a80981322cb1b92c