### PR TITLE
refactor: centralize user profile type

### DIFF
--- a/get_user_profile/components/profile.tsx
+++ b/get_user_profile/components/profile.tsx
@@ -1,15 +1,5 @@
 import React from "react";
-
-interface UserProfile {
-  display_name: string;
-  images: Array<{ url: string }>;
-  id: string;
-  email: string;
-  uri: string;
-  external_urls?: { spotify: string };
-  followers?: { href: string; total: number };
-  href: string;
-}
+import type { UserProfile } from "../types";
 
 interface ProfileProps {
   profile: UserProfile;

--- a/get_user_profile/pages/api/__tests__/profile.test.ts
+++ b/get_user_profile/pages/api/__tests__/profile.test.ts
@@ -1,4 +1,5 @@
 import { fetchProfile } from "../profile";
+import type { UserProfile } from "../../../types";
 
 describe("fetchProfile", () => {
   const token = "test-token";

--- a/get_user_profile/pages/api/profile.ts
+++ b/get_user_profile/pages/api/profile.ts
@@ -1,3 +1,5 @@
+import type { UserProfile } from "../../types";
+
 export const fetchProfile = async (token: string): Promise<UserProfile> => {
   const response = await fetch("https://api.spotify.com/v1/me", {
     method: "GET",

--- a/get_user_profile/pages/api/types.d.ts
+++ b/get_user_profile/pages/api/types.d.ts
@@ -1,35 +1,3 @@
-interface UserProfile {
-  country: string;
-  display_name: string;
-  email: string;
-  explicit_content: {
-    filter_enabled: boolean;
-    filter_locked: boolean;
-  };
-  external_urls: { spotify: string };
-  followers?: { href: string; total: number };
-  href: string;
-  id: string;
-  images: Image[];
-  product: string;
-  type: string;
-  uri: string;
-}
-
-interface Image {
-  url: string;
-  height: number;
-  width: number;
-}
-
-interface ImportMetaEnv {
-  readonly VITE_SPOTIFY_CLIENT_ID: string;
-}
-
-interface ImportMeta {
-  readonly env: ImportMetaEnv;
-}
-
 interface SpotifyPlaylistsResponse {
   href: string;
   items: SpotifyPlaylistResponse[];

--- a/get_user_profile/pages/index.tsx
+++ b/get_user_profile/pages/index.tsx
@@ -8,6 +8,7 @@ import {
   getAccessToken,
 } from "../src/authCodeWithPkce";
 import { useAuth } from "../src/AuthContext";
+import type { UserProfile } from "../types";
 
 const clientId = process.env.NEXT_PUBLIC_SPOTIFY_CLIENT_ID;
 export default function Home() {

--- a/get_user_profile/src/script.ts
+++ b/get_user_profile/src/script.ts
@@ -5,6 +5,7 @@ import {
   getAccessToken,
   refreshAccessToken,
 } from "./authCodeWithPkce";
+import type { UserProfile } from "../types";
 
 const clientId = import.meta.env.VITE_SPOTIFY_CLIENT_ID;
 const params = new URLSearchParams(window.location.search);

--- a/get_user_profile/types/index.d.ts
+++ b/get_user_profile/types/index.d.ts
@@ -1,4 +1,4 @@
-interface UserProfile {
+export interface UserProfile {
   country: string;
   display_name: string;
   email: string;
@@ -16,21 +16,25 @@ interface UserProfile {
   uri: string;
 }
 
-interface Image {
+export interface Image {
   url: string;
   height: number;
   width: number;
 }
 
-interface ImportMetaEnv {
-  readonly VITE_SPOTIFY_CLIENT_ID: string;
+declare global {
+  interface ImportMetaEnv {
+    readonly VITE_SPOTIFY_CLIENT_ID: string;
+  }
+
+  interface ImportMeta {
+    readonly env: ImportMetaEnv;
+  }
+
+  interface Window {
+    onSpotifyWebPlaybackSDKReady?: () => void;
+    Spotify: any;
+  }
 }
 
-interface ImportMeta {
-  readonly env: ImportMetaEnv;
-}
-
-interface Window {
-  onSpotifyWebPlaybackSDKReady?: () => void;
-  Spotify: any;
-}
+export {};


### PR DESCRIPTION
## Summary
- remove local `UserProfile` interface from profile component
- move shared type definitions to `types/index.d.ts`
- update components and API modules to import `UserProfile` from the shared file

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898c1d6526c8332a5e250ae7923fd05