### PR TITLE
refactor: use track id as playlist detail key

### DIFF
--- a/get_user_profile/components/playlistDetail.tsx
+++ b/get_user_profile/components/playlistDetail.tsx
@@ -60,9 +60,13 @@ export const PlaylistDetail: React.FC<PlaylistDetailProps> = ({
           className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 3xl:grid-cols-7 4xl:grid-cols-8"
         >
           {playlistDetail.tracks?.items?.map((item, index) => {
-            const features = trackFeatures[item.track.id];
+            const trackId = item.track?.id;
+            const features = trackId ? trackFeatures[trackId] : undefined;
             return (
-              <div key={index} className="bg-gray-700 p-4 rounded-lg shadow">
+              <div
+                key={trackId ?? `temp-${index}`}
+                className="bg-gray-700 p-4 rounded-lg shadow"
+              >
                 {item.track.album.images.length > 0 && (
                   <img
                     src={item.track.album.images[0].url}


### PR DESCRIPTION
## Summary
- use track ID as React key in playlist details
- provide temporary fallback key when ID is missing

## Testing
- `cd get_user_profile && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898c1e1b6a08332a6e1115ea42a2eae