### PR TITLE
Use env variable for Spotify redirect URI

### DIFF
--- a/get_user_profile/.env.local
+++ b/get_user_profile/.env.local
@@ -1,0 +1,3 @@
+NEXT_PUBLIC_SPOTIFY_CLIENT_ID=your_client_id_here
+NEXT_PUBLIC_REDIRECT_URI=http://localhost:3000/callback
+# For different environments, override NEXT_PUBLIC_REDIRECT_URI in .env.development.local, .env.production, etc.

--- a/get_user_profile/README.md
+++ b/get_user_profile/README.md
@@ -12,13 +12,16 @@ To run this demo you will need:
 
 ## Usage
 
-Create an app in your [Spotify Developer Dashboard](https://developer.spotify.com/dashboard/), set the redirect URI to `http://localhost:3000/callback` and copy your Client ID.
+Create an app in your [Spotify Developer Dashboard](https://developer.spotify.com/dashboard/), set the redirect URI to match your environment (for example `http://localhost:3000/callback` for local development) and copy your Client ID.
 
-In this directory, create a `.env.local` file and add your Spotify Client ID:
+In this directory, create a `.env.local` file and add your Spotify Client ID and redirect URI:
 
 ```env
 NEXT_PUBLIC_SPOTIFY_CLIENT_ID=your_client_id_here
+NEXT_PUBLIC_REDIRECT_URI=http://localhost:3000/callback
 ```
+
+If you need different redirect URIs for multiple environments (development, production, etc.), create environment specific files such as `.env.development.local` or `.env.production.local` and override `NEXT_PUBLIC_REDIRECT_URI` with the appropriate value.
 
 Install dependencies and start the development server:
 

--- a/get_user_profile/src/authCodeWithPkce.ts
+++ b/get_user_profile/src/authCodeWithPkce.ts
@@ -12,7 +12,9 @@ export async function redirectToAuthCodeFlow(clientId: string) {
   const params = new URLSearchParams();
   params.append("client_id", clientId);
   params.append("response_type", "code");
-  params.append("redirect_uri", "http://localhost:3000/callback");
+  const redirectUri =
+    process.env.NEXT_PUBLIC_REDIRECT_URI ?? "http://localhost:3000/callback";
+  params.append("redirect_uri", redirectUri);
   params.append(
     "scope",
     "user-read-private user-read-email user-read-currently-playing user-read-playback-state user-modify-playback-state app-remote-control playlist-read-private user-read-playback-position user-library-read"
@@ -40,7 +42,9 @@ export async function getAccessToken(clientId: string, code: string) {
   params.append("client_id", clientId);
   params.append("grant_type", "authorization_code");
   params.append("code", code);
-  params.append("redirect_uri", "http://localhost:3000/callback");
+  const redirectUri =
+    process.env.NEXT_PUBLIC_REDIRECT_URI ?? "http://localhost:3000/callback";
+  params.append("redirect_uri", redirectUri);
   params.append("code_verifier", verifier);
 
   const result = await fetch("https://accounts.spotify.com/api/token", {


### PR DESCRIPTION
## Summary
- read Spotify redirect URI from `NEXT_PUBLIC_REDIRECT_URI` env
- document new variable in `.env.local` and README with per-environment guidance

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898c220fbe88332af566bdcd8c8af5a