### PR TITLE
Check fetch responses and add tests

### DIFF
--- a/get_user_profile/pages/api/__tests__/player.test.ts
+++ b/get_user_profile/pages/api/__tests__/player.test.ts
@@ -1,0 +1,43 @@
+import { fetchPlayerState, startPlayback } from "../player";
+
+describe("player API error handling", () => {
+  const token = "test-token";
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("throws an error when fetchPlayerState response is not ok", async () => {
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue({ ok: false } as any);
+
+    await expect(fetchPlayerState(token)).rejects.toThrow(
+      "Failed to fetch player state"
+    );
+    expect(fetchMock).toHaveBeenCalledWith("https://api.spotify.com/v1/me/player", {
+      method: "GET",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+  });
+
+  it("throws an error when startPlayback response is not ok", async () => {
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue({ ok: false } as any);
+
+    await expect(startPlayback(token, "spotify:album:1", 0)).rejects.toThrow(
+      "Failed to start playback"
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.spotify.com/v1/me/player/play",
+      expect.objectContaining({
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+      })
+    );
+  });
+});

--- a/get_user_profile/pages/api/__tests__/playlist.test.ts
+++ b/get_user_profile/pages/api/__tests__/playlist.test.ts
@@ -1,0 +1,59 @@
+import { fetchPlaylist, fetchPlaylistItems, fetchPlaylists } from "../playlist";
+
+describe("playlist API error handling", () => {
+  const token = "test-token";
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("throws an error when fetchPlaylists response is not ok", async () => {
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue({ ok: false } as any);
+
+    await expect(fetchPlaylists(token, 20, 0)).rejects.toThrow(
+      "Failed to fetch playlists"
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      `https://api.spotify.com/v1/me/playlists?limit=20&offset=0`,
+      {
+        method: "GET",
+        headers: { Authorization: `Bearer ${token}` },
+      }
+    );
+  });
+
+  it("throws an error when fetchPlaylist response is not ok", async () => {
+    const playlistId = "abc";
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue({ ok: false } as any);
+
+    await expect(
+      fetchPlaylist(token, playlistId, 20, 0)
+    ).rejects.toThrow("Failed to fetch playlist");
+    expect(fetchMock).toHaveBeenCalledWith(
+      `https://api.spotify.com/v1/playlists/${playlistId}?limit=20&offset=0`,
+      {
+        method: "GET",
+        headers: { Authorization: `Bearer ${token}` },
+      }
+    );
+  });
+
+  it("throws an error when fetchPlaylistItems response is not ok", async () => {
+    const url = "https://api.spotify.com/v1/playlist/items";
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue({ ok: false } as any);
+
+    await expect(fetchPlaylistItems(token, url)).rejects.toThrow(
+      "Failed to fetch playlist items"
+    );
+    expect(fetchMock).toHaveBeenCalledWith(url, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+  });
+});

--- a/get_user_profile/pages/api/__tests__/track.test.ts
+++ b/get_user_profile/pages/api/__tests__/track.test.ts
@@ -1,4 +1,4 @@
-import { fetchAudioAnalysis } from "../track";
+import { fetchAudioAnalysis, fetchAudioFeatures } from "../track";
 
 describe("fetchAudioAnalysis", () => {
   const token = "test-token";
@@ -113,5 +113,31 @@ describe("fetchAudioAnalysis", () => {
 
     expect(result).toEqual(partialResponse);
     expect((result as any).sections).toBeUndefined();
+  });
+});
+
+describe("fetchAudioFeatures", () => {
+  const token = "test-token";
+  const trackId = "123";
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("throws an error when the fetch response is not ok", async () => {
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+    } as any);
+
+    await expect(fetchAudioFeatures(token, trackId)).rejects.toThrow(
+      "Failed to fetch audio features"
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      `https://api.spotify.com/v1/audio-features/${trackId}`,
+      {
+        method: "GET",
+        headers: { Authorization: `Bearer ${token}` },
+      }
+    );
   });
 });

--- a/get_user_profile/pages/api/player.ts
+++ b/get_user_profile/pages/api/player.ts
@@ -3,6 +3,9 @@ export const fetchPlayerState = async (code: string): Promise<any | null> => {
     method: "GET",
     headers: { Authorization: `Bearer ${code}` },
   });
+  if (!res.ok) {
+    throw new Error("Failed to fetch player state");
+  }
   if (res.status === 204) {
     return null;
   }
@@ -14,6 +17,9 @@ export const fetchAvailableDevices = async (code: string): Promise<any[]> => {
     method: "GET",
     headers: { Authorization: `Bearer ${code}` },
   });
+  if (!res.ok) {
+    throw new Error("Failed to fetch available devices");
+  }
   const data = await res.json();
   return Array.isArray(data.devices) ? data.devices : [];
 };
@@ -25,7 +31,7 @@ export const startPlayback = async (
   deviceId?: string,
   positionMs?: number
 ): Promise<void> => {
-  await fetch(
+  const res = await fetch(
     `https://api.spotify.com/v1/me/player/play${
       deviceId ? `?device_id=${deviceId}` : ""
     }`,
@@ -42,13 +48,16 @@ export const startPlayback = async (
       }),
     }
   );
+  if (!res.ok) {
+    throw new Error("Failed to start playback");
+  }
 };
 
 export const resumePlayback = async (
   token: string,
   deviceId?: string
 ): Promise<void> => {
-  await fetch(
+  const res = await fetch(
     `https://api.spotify.com/v1/me/player/play${
       deviceId ? `?device_id=${deviceId}` : ""
     }`,
@@ -58,6 +67,9 @@ export const resumePlayback = async (
       body: JSON.stringify({}),
     }
   );
+  if (!res.ok) {
+    throw new Error("Failed to resume playback");
+  }
 };
 
 /**
@@ -74,7 +86,7 @@ export const transferPlayback = async (
   deviceId: string,
   play = false
 ): Promise<void> => {
-  await fetch("https://api.spotify.com/v1/me/player", {
+  const res = await fetch("https://api.spotify.com/v1/me/player", {
     method: "PUT",
     headers: {
       Authorization: `Bearer ${token}`,
@@ -82,13 +94,16 @@ export const transferPlayback = async (
     },
     body: JSON.stringify({ device_ids: [deviceId], play }),
   });
+  if (!res.ok) {
+    throw new Error("Failed to transfer playback");
+  }
 };
 
 export const pausePlayback = async (
   token: string,
   deviceId?: string
 ): Promise<void> => {
-  await fetch(
+  const res = await fetch(
     `https://api.spotify.com/v1/me/player/pause${
       deviceId ? `?device_id=${deviceId}` : ""
     }`,
@@ -97,13 +112,16 @@ export const pausePlayback = async (
       headers: { Authorization: `Bearer ${token}` },
     }
   );
+  if (!res.ok) {
+    throw new Error("Failed to pause playback");
+  }
 };
 
 export const nextTrack = async (
   token: string,
   deviceId?: string
 ): Promise<void> => {
-  await fetch(
+  const res = await fetch(
     `https://api.spotify.com/v1/me/player/next${
       deviceId ? `?device_id=${deviceId}` : ""
     }`,
@@ -112,13 +130,16 @@ export const nextTrack = async (
       headers: { Authorization: `Bearer ${token}` },
     }
   );
+  if (!res.ok) {
+    throw new Error("Failed to skip to next track");
+  }
 };
 
 export const previousTrack = async (
   token: string,
   deviceId?: string
 ): Promise<void> => {
-  await fetch(
+  const res = await fetch(
     `https://api.spotify.com/v1/me/player/previous${
       deviceId ? `?device_id=${deviceId}` : ""
     }`,
@@ -127,6 +148,9 @@ export const previousTrack = async (
       headers: { Authorization: `Bearer ${token}` },
     }
   );
+  if (!res.ok) {
+    throw new Error("Failed to skip to previous track");
+  }
 };
 
 export const seekPlayback = async (
@@ -134,7 +158,7 @@ export const seekPlayback = async (
   positionMs: number,
   deviceId?: string
 ): Promise<void> => {
-  await fetch(
+  const res = await fetch(
     `https://api.spotify.com/v1/me/player/seek?position_ms=${positionMs}${
       deviceId ? `&device_id=${deviceId}` : ""
     }`,
@@ -143,6 +167,9 @@ export const seekPlayback = async (
       headers: { Authorization: `Bearer ${token}` },
     }
   );
+  if (!res.ok) {
+    throw new Error("Failed to seek playback");
+  }
 };
 
 export const setVolume = async (
@@ -150,7 +177,7 @@ export const setVolume = async (
   volumePercent: number,
   deviceId?: string
 ): Promise<void> => {
-  await fetch(
+  const res = await fetch(
     `https://api.spotify.com/v1/me/player/volume?volume_percent=${volumePercent}${
       deviceId ? `&device_id=${deviceId}` : ""
     }`,
@@ -159,6 +186,9 @@ export const setVolume = async (
       headers: { Authorization: `Bearer ${token}` },
     }
   );
+  if (!res.ok) {
+    throw new Error("Failed to set volume");
+  }
 };
 
 export const setShuffle = async (
@@ -166,7 +196,7 @@ export const setShuffle = async (
   state: boolean,
   deviceId?: string
 ): Promise<void> => {
-  await fetch(
+  const res = await fetch(
     `https://api.spotify.com/v1/me/player/shuffle?state=${state}${
       deviceId ? `&device_id=${deviceId}` : ""
     }`,
@@ -175,6 +205,9 @@ export const setShuffle = async (
       headers: { Authorization: `Bearer ${token}` },
     }
   );
+  if (!res.ok) {
+    throw new Error("Failed to set shuffle");
+  }
 };
 
 export const setRepeat = async (
@@ -182,7 +215,7 @@ export const setRepeat = async (
   state: "off" | "track" | "context",
   deviceId?: string
 ): Promise<void> => {
-  await fetch(
+  const res = await fetch(
     `https://api.spotify.com/v1/me/player/repeat?state=${state}${
       deviceId ? `&device_id=${deviceId}` : ""
     }`,
@@ -191,4 +224,7 @@ export const setRepeat = async (
       headers: { Authorization: `Bearer ${token}` },
     }
   );
+  if (!res.ok) {
+    throw new Error("Failed to set repeat");
+  }
 };

--- a/get_user_profile/pages/api/playlist.ts
+++ b/get_user_profile/pages/api/playlist.ts
@@ -10,6 +10,9 @@ export const fetchPlaylists = async (
       headers: { Authorization: `Bearer ${code}` },
     }
   );
+  if (!result.ok) {
+    throw new Error("Failed to fetch playlists");
+  }
   return await result.json();
 };
 
@@ -26,6 +29,9 @@ export const fetchPlaylist = async (
       headers: { Authorization: `Bearer ${code}` },
     }
   );
+  if (!result.ok) {
+    throw new Error("Failed to fetch playlist");
+  }
   return await result.json();
 };
 export const fetchPlaylistItems = async (
@@ -36,5 +42,8 @@ export const fetchPlaylistItems = async (
     method: "GET",
     headers: { Authorization: `Bearer ${code}` },
   });
+  if (!result.ok) {
+    throw new Error("Failed to fetch playlist items");
+  }
   return await result.json();
 };


### PR DESCRIPTION
## Summary
- verify `fetch` responses in playlist API and throw errors when Spotify responses fail
- propagate player control errors by checking `response.ok` across playback endpoints
- add unit tests covering error scenarios for playlist, player and track APIs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898c1db40dc83328b13066b9afb6598