### PR TITLE
Translate comments to Japanese and add language guideline

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@
 - Authorization examples
     - [Client Credentials](/authorization/client_credentials)
 - [Get User Profile example](/get_user_profile/)
+
+## Language Guidelines / 言語ガイドライン
+
+このリポジトリではコメントやドキュメントを日本語で記述します。新しくコードや文書を追加する際は、日本語を使用して統一してください。

--- a/get_user_profile/README.md
+++ b/get_user_profile/README.md
@@ -26,3 +26,7 @@ Install dependencies and start the development server:
 npm install
 npm run dev
 ```
+
+## 言語ガイドライン
+
+このプロジェクトではコメントやドキュメントを日本語で記述し、言語を統一します。

--- a/get_user_profile/components/__tests__/player.test.tsx
+++ b/get_user_profile/components/__tests__/player.test.tsx
@@ -249,11 +249,11 @@ describe("Player", () => {
     const seek = sliders[0] as HTMLInputElement;
     const volumeSlider = sliders[1] as HTMLInputElement;
 
-    // Initial values are clamped
+    // 初期値はクランプされる
     expect(seek.value).toBe("1000");
     expect(volumeSlider.value).toBe("1");
 
-    // Simulate user moving sliders beyond bounds
+    // ユーザーがスライダーを範囲外に動かした場合をシミュレート
     seek.value = "1500";
     volumeSlider.value = "2";
     await act(async () => {
@@ -306,7 +306,7 @@ describe("Player", () => {
       disabledVolume.dispatchEvent(new Event("input", { bubbles: true }));
     });
 
-    // Handlers should not fire again when controls are disabled
+    // コントロールが無効なときはハンドラーが再度呼ばれないはず
     expect(onSeek).toHaveBeenCalledTimes(1);
     expect(onVolumeChange).toHaveBeenCalledTimes(1);
   });

--- a/get_user_profile/components/player.tsx
+++ b/get_user_profile/components/player.tsx
@@ -9,7 +9,7 @@ import {
   FaVolumeUp,
 } from "react-icons/fa";
 
-// Format milliseconds to "hh:mm:ss" or "mm:ss" when hours are zero
+// ミリ秒を「hh:mm:ss」または「mm:ss」に整形（時間が0の場合はmm:ss）
 const formatTime = (ms: number): string => {
   const totalSeconds = Math.floor(ms / 1000);
   const hours = Math.floor(totalSeconds / 3600);
@@ -22,53 +22,53 @@ const formatTime = (ms: number): string => {
 };
 
 /**
- * Modal-like player that slides down from the top of the page to control the
- * current track. When `visible` is false nothing is rendered. Each control is
- * disabled when `controlsDisabled` is true, preventing interaction.
+ * ページ上部からスライドダウンして再生中のトラックを操作するモーダル風プレイヤー。
+ * `visible` が false のときは何も描画されない。`controlsDisabled` が true の場合、
+ * 各操作は無効化される。
  */
 interface PlayerProps {
-  /** Whether the modal should be shown */
+  /** モーダルを表示するかどうか */
   visible: boolean;
-  /** Track information for the currently selected song */
+  /** 選択中の曲のトラック情報 */
   track: SpotifyTrackObject | null;
-  /** Indicates if Spotify is currently playing */
+  /** Spotify が再生中かどうか */
   isPlaying: boolean;
   /**
-   * Disables all playback controls. When true the icons render with reduced
-   * opacity and their handlers become no-ops.
+   * すべての再生操作を無効化する。true のときアイコンは半透明になり、
+   * ハンドラは何もしない。
    */
   controlsDisabled: boolean;
-  /** Toggle play/pause; should be a no-op if controlsDisabled */
+  /** 再生/一時停止を切り替える。controlsDisabled の場合は何もしない */
   onTogglePlay: () => void;
-  /** Skip to the previous track; no-op if controlsDisabled */
+  /** 前のトラックへスキップ。controlsDisabled の場合は何もしない */
   onPrev: () => void;
-  /** Skip to the next track; no-op if controlsDisabled */
+  /** 次のトラックへスキップ。controlsDisabled の場合は何もしない */
   onNext: () => void;
-  /** Called when the × button is clicked to close the modal */
+  /** × ボタンがクリックされたときにモーダルを閉じるために呼び出される */
   onClose: () => void;
-  /** Current playback position in ms */
+  /** 現在の再生位置（ms） */
   position: number;
-  /** Duration of current track in ms */
+  /** 現在のトラックの長さ（ms） */
   duration: number;
-  /** Volume 0-1 */
+  /** 音量 0〜1 */
   volume: number;
-  /** Whether shuffle mode is enabled */
+  /** シャッフルモードが有効かどうか */
   shuffle: boolean;
-  /** Current repeat mode */
+  /** 現在のリピートモード */
   repeat: "off" | "track" | "context";
-  /** Seek handler */
+  /** シーク処理 */
   onSeek: (ms: number) => void;
-  /** Volume change handler */
+  /** 音量変更処理 */
   onVolumeChange: (v: number) => void;
-  /** Toggle shuffle handler */
+  /** シャッフル切り替え処理 */
   onToggleShuffle: () => void;
-  /** Toggle repeat handler */
+  /** リピート切り替え処理 */
   onToggleRepeat: () => void;
-  /** List of available devices */
+  /** 利用可能なデバイスの一覧 */
   devices: SpotifyDevice[];
-  /** Currently selected device id */
+  /** 現在選択中のデバイスID */
   deviceId: string | null;
-  /** Device selection handler */
+  /** デバイス選択処理 */
   onDeviceSelect: (id: string) => void;
 }
 
@@ -103,7 +103,7 @@ export const Player: React.FC<PlayerProps> = ({
           visible ? "translate-y-0" : "-translate-y-full"
         }`}
       >
-        {/* Clicking the × delegates to onClose so the parent can hide the modal */}
+        {/* × をクリックすると onClose に委譲され、親がモーダルを閉じる */}
         <button className="absolute top-2 right-2 text-2xl" onClick={onClose}>
           ×
         </button>
@@ -173,8 +173,8 @@ export const Player: React.FC<PlayerProps> = ({
           />
         </div>
         {/**
-         * Slider for seeking within the track. Clamp values to avoid NaN or
-         * values outside the duration range, especially when duration is 0.
+         * トラック内をシークするためのスライダー。duration が 0 の場合などに
+         * NaN や範囲外の値にならないよう制限する。
          */}
         <div className="flex items-center w-3/4 mt-4">
           <span className="mr-2 text-sm" data-testid="elapsed-time">

--- a/get_user_profile/pages/_error.tsx
+++ b/get_user_profile/pages/_error.tsx
@@ -9,7 +9,7 @@ interface ErrorProps {
 
 function Error({ statusCode, hasGetInitialPropsRun, err }: ErrorProps) {
   if (!hasGetInitialPropsRun && err) {
-    // getInitialProps was not called on the client, this is a client-side error
+    // クライアントで getInitialProps が呼ばれていないため、これはクライアント側のエラー
     console.error("Client-side error:", err);
   }
 

--- a/get_user_profile/pages/playlists/[id]/index.tsx
+++ b/get_user_profile/pages/playlists/[id]/index.tsx
@@ -76,7 +76,7 @@ const PlaylistDetailPage = () => {
           playlistDetail.tracks!.next!
         );
 
-        // Deduplicate tracks by ID before updating state
+        // 状態を更新する前にIDでトラックの重複を排除
         const uniqueItems = tracks.items.filter(
           (item) =>
             item.track &&

--- a/get_user_profile/pages/playlists/index.tsx
+++ b/get_user_profile/pages/playlists/index.tsx
@@ -39,7 +39,7 @@ export default function PlaylistsPage() {
           setHasMore(false);
           return;
         }
-        // Deduplicate playlists by ID before updating state
+        // 状態を更新する前にIDでプレイリストの重複を排除
         setPlaylists((prev) => {
           const existingItems = prev?.items || [];
           const newItems = playlistsData.items.filter(

--- a/get_user_profile/pages/web-player.tsx
+++ b/get_user_profile/pages/web-player.tsx
@@ -1,6 +1,6 @@
-// Web player page that lists user playlists and, upon selection, opens a
-// slide-in Player modal for controlling playback via Spotify's Web API.
-// The modal consumes the first playable track of the chosen playlist.
+// ユーザープレイリストを一覧表示し、選択すると
+// Spotify Web APIで再生を操作できるスライド式プレイヤーモーダルを開くページ。
+// モーダルは選択したプレイリストの最初に再生可能なトラックを利用する。
 import React, { useEffect, useRef, useState } from "react";
 import Script from "next/script";
 import { useAuth } from "../src/AuthContext";

--- a/get_user_profile/src/AuthContext.tsx
+++ b/get_user_profile/src/AuthContext.tsx
@@ -20,7 +20,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   const [refreshToken, setRefreshTokenState] = useState<string | null>(null);
   const [expiresAt, setExpiresAt] = useState<number | null>(null);
 
-  // Load tokens from localStorage on initial mount
+  // 初回マウント時に localStorage からトークンを読み込む
   useEffect(() => {
     if (typeof window === "undefined") return;
     try {
@@ -41,7 +41,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     }
   }, []);
 
-  // Automatically refresh the access token before it expires
+  // アクセストークンの有効期限が切れる前に自動更新する
   useEffect(() => {
     if (!token || !refreshToken || !expiresAt) return;
     const clientId = process.env.NEXT_PUBLIC_SPOTIFY_CLIENT_ID;

--- a/get_user_profile/src/script.ts
+++ b/get_user_profile/src/script.ts
@@ -1,5 +1,5 @@
-// Because this is a literal single page application
-// we detect a callback from Spotify by checking for the hash fragment
+// 文字通りのシングルページアプリであるため
+// ハッシュフラグメントを確認してSpotifyからのコールバックを検出する
 import {
   redirectToAuthCodeFlow,
   getAccessToken,
@@ -45,7 +45,7 @@ async function getStoredAccessToken(): Promise<string | null> {
 
     if (expires) {
       const expiresAt = parseInt(expires, 10);
-      // refresh if the token is expired or will expire within the next minute
+      // トークンが期限切れか1分以内に期限切れとなる場合は更新する
       if (expiresAt - Date.now() < 60_000) {
         if (!refreshToken) return null;
         try {


### PR DESCRIPTION
## Summary
- translate remaining English comments in player component and playlist pages to Japanese
- document repository language guideline in READMEs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898c1fa33708332b4b0f16954ddea39